### PR TITLE
fix: updated leaderboard api to return sanitized users

### DIFF
--- a/app/api/v1/leaderboard/index.js
+++ b/app/api/v1/leaderboard/index.js
@@ -20,7 +20,7 @@ router.route("/").get((req, res, next) => {
       // map the user objects to public (just name, picture, and points) for privacy reasons
       res.json({
         error: null,
-        leaderboard: users.map((u) => u.getUserProfile()),
+        leaderboard: users.map((u) => u.getPublicProfile()),
       });
     })
     .catch(next);


### PR DESCRIPTION
"Detailed" changes:

`/app/api/v1/leaderboard/index.js`
- changed `getUserProfile` to `getPublicProfile`