### PR TITLE
Fix ReferenceError: Use Schema.Types.ObjectId for committee fields in InternshipApplications schema

### DIFF
--- a/app/api/v1/internship/models/InternshipApplication.js
+++ b/app/api/v1/internship/models/InternshipApplication.js
@@ -61,16 +61,16 @@ const InternshipApplicationSchema = new Schema(
 
     // Committee choices and responses
     firstChoiceCommittee: {
-      type: ObjectId,
+      type: Schema.Types.ObjectId,
       ref: "Committee",
       required: [true, "You must apply to at least one commitee"],
     },
     secondChoiceCommittee: {
-      type: ObjectId,
+      type: Schema.Types.ObjectId,
       ref: "Committee"
     },
     thirdChoiceCommittee: {
-      type: ObjectId,
+      type: Schema.Types.ObjectId,
       ref: "Committee"
     },
     firstChoiceResponses: [{

--- a/app/api/v1/internship/models/InternshipApplication.js
+++ b/app/api/v1/internship/models/InternshipApplication.js
@@ -63,7 +63,7 @@ const InternshipApplicationSchema = new Schema(
     firstChoiceCommittee: {
       type: Schema.Types.ObjectId,
       ref: "Committee",
-      required: [true, "You must apply to at least one commitee"],
+      required: [true, "You must apply to at least one committee"],
     },
     secondChoiceCommittee: {
       type: Schema.Types.ObjectId,


### PR DESCRIPTION
Committee choices are rewritten as:

```
    firstChoiceCommittee: {
      type: Schema.Types.ObjectId,
      ref: "Committee",
      required: [true, "You must apply to at least one commitee"],
    },
    secondChoiceCommittee: {
      type: Schema.Types.ObjectId,
      ref: "Committee"
    },
    thirdChoiceCommittee: {
      type: Schema.Types.ObjectId,
      ref: "Committee"
    },
```

The original `ObjectID` is not a global variable in Node.js or Mongoose, so ```Schema.Types.ObjectID``` must be used in order to ensure proper referencing.