### PR TITLE
Added uclaacm workspace and auto admin domain

### DIFF
--- a/app/api/v1/auth/index.js
+++ b/app/api/v1/auth/index.js
@@ -96,7 +96,9 @@ router.post('/login', (req, res, next) => {
     .then((ticket) => {
       const { email } = ticket.getPayload();
 
-      if (!email.toLowerCase().endsWith(config.google.hostedDomain)) {
+      const lowerEmail = email.toLowerCase();
+      const isAllowed = config.google.allowedDomains.some((domain) => lowerEmail.endsWith(`@${domain}`));
+      if (!isAllowed) {
         return next(
           new error.Unauthorized('Unauthorized email'),
         );
@@ -122,6 +124,7 @@ router.post('/login', (req, res, next) => {
               lastName: familyName,
               picture,
               state: 'PENDING',
+              accessType: userEmail.toLowerCase().endsWith(`@${config.google.adminDomain}`) ? 'ADMIN' : 'STANDARD',
               year: 1,
               major: 'Undeclared',
             };

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -23,7 +23,8 @@ module.exports = {
     apiKey: process.env.GOOGLE_API_KEY,
     authDomain: process.env.GOOGLE_AUTH_DOMAIN,
     clientId: process.env.GOOGLE_CLIENT_ID,
-    hostedDomain: 'g.ucla.edu',
+    allowedDomains: ['g.ucla.edu', 'ucla.edu', 'uclaacm.com'],
+    adminDomain: 'uclaacm.com',
   },
 
   sheets: {


### PR DESCRIPTION
Enforces users can only be from @g.ucla.edu, @ucla.edu, or @uclaacm.com. If Account is @uclaacm.com, user is auto promoted to admin.

Test it out at [members-staging.uclaacm.com](members-staging.uclaacm.com). Manually set up there for testing