### PR TITLE
Fix/officer control panel

### DIFF
--- a/app/api/v1/auth/committeeScope.js
+++ b/app/api/v1/auth/committeeScope.js
@@ -1,0 +1,41 @@
+const error = require('../../../error');
+
+const isOfficerInCommittee = (user, committee) => (
+  !!user
+  && user.isOfficer()
+  && typeof committee === 'string'
+  && committee.length > 0
+  && user.hasCommittee(committee)
+);
+
+const canManageCommitteeResource = (user, committee) => (
+  !!user
+  && (user.isAdmin() || isOfficerInCommittee(user, committee))
+);
+
+const findCommitteesByImageUUID = async (Event, uuid) => {
+  if (!uuid) return [];
+
+  const events = await Event.findAll({
+    where: {
+      cover: {
+        $like: `%/image/raw/${uuid}%`,
+      },
+    },
+  });
+
+  // Deduplicate and drop invalid values.
+  return [...new Set(events.map((event) => event.committee).filter(Boolean))];
+};
+
+const assertCanManageCommitteeResource = (user, committee, resourceLabel) => {
+  if (!canManageCommitteeResource(user, committee)) {
+    throw new error.Forbidden(`You do not have permission to delete this ${resourceLabel}.`);
+  }
+};
+
+module.exports = {
+  canManageCommitteeResource,
+  findCommitteesByImageUUID,
+  assertCanManageCommitteeResource,
+};

--- a/app/api/v1/membership/event/index.js
+++ b/app/api/v1/membership/event/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const error = require('../../../../error');
 const { Event } = require('../../../../db');
+const { assertCanManageCommitteeResource } = require('../../auth/committeeScope');
 
 const router = express.Router();
 
@@ -128,19 +129,14 @@ router
       .catch(next);
   })
   /**
-   * For all further requests on this route, the user needs to be an admin
-   */
-  .all((req, res, next) => {
-    if (!req.user.isAdmin()) return next(new error.Forbidden());
-    return next();
-  })
-  /**
    * Updates an event given an event UUID and the partial object with updates
    *
    * URI should contain the UUID and the POST body should contain an 'event' object
    * with updated fields.
    */
   .patch((req, res, next) => {
+    if (!req.user.isAdmin()) return next(new error.Forbidden());
+
     if (!req.params.uuid || !req.params.uuid.trim() || !req.body.event) {
       return next(new error.BadRequest());
     }
@@ -171,10 +167,20 @@ router
    */
   .delete((req, res, next) => {
     if (!req.params.uuid) return next(new error.BadRequest());
-    return Event.destroyByUUID(req.params.uuid)
-      .then((numDeleted) => {
-        res.json({ error: null, numDeleted });
-        return null;
+
+    return Event.findByUUID(req.params.uuid)
+      .then((event) => {
+        if (!event) {
+          res.json({ error: null, numDeleted: 0 });
+          return null;
+        }
+
+        assertCanManageCommitteeResource(req.user, event.committee, 'event');
+        return Event.destroyByUUID(req.params.uuid)
+          .then((numDeleted) => {
+            res.json({ error: null, numDeleted });
+            return null;
+          });
       })
       .catch(next);
   });

--- a/app/api/v1/membership/event/index.js
+++ b/app/api/v1/membership/event/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const error = require('../../../../error');
 const { Event } = require('../../../../db');
-const { assertCanManageCommitteeResource } = require('../../auth/committeeScope');
+const { assertCanManageCommitteeResource, canManageCommitteeResource } = require('../../auth/committeeScope');
 
 const router = express.Router();
 
@@ -96,12 +96,16 @@ router
     if (!req.body.event) return next(new error.BadRequest());
 
     if (!req.user.isAdmin()) {
-      if (!req.body.event.committee || !req.body.event.committee.trim()) {
+      const committee = typeof req.body.event.committee === 'string'
+        ? req.body.event.committee.trim()
+        : '';
+
+      if (!committee) {
         return next(new error.Forbidden('You do not have permission to create events outside your committee.'));
       }
 
       try {
-        assertCanManageCommitteeResource(req.user, req.body.event.committee, 'event');
+        assertCanManageCommitteeResource(req.user, committee, 'event');
       } catch (err) {
         return next(err);
       }
@@ -147,7 +151,7 @@ router
    * with updated fields.
    */
   .patch((req, res, next) => {
-    if (!req.user.isAdmin()) return next(new error.Forbidden());
+    if (!req.user.isAdmin() && !req.user.isOfficer()) return next(new error.Forbidden());
 
     if (!req.params.uuid || !req.params.uuid.trim() || !req.body.event) {
       return next(new error.BadRequest());
@@ -163,8 +167,22 @@ router
     return Event.findByUUID(req.params.uuid)
       .then((event) => {
         if (!event) throw new error.BadRequest('No such event found');
+
+        if (!req.user.isAdmin() && !canManageCommitteeResource(req.user, event.committee)) {
+          throw new error.Forbidden('You do not have permission to update this event.');
+        }
+
+        const updates = Event.sanitize(req.body.event);
+        if (
+          !req.user.isAdmin()
+          && updates.committee
+          && !canManageCommitteeResource(req.user, updates.committee)
+        ) {
+          throw new error.Forbidden('You do not have permission to move this event to another committee.');
+        }
+
         // update the event with the new information after sanitizing the input
-        return event.update(Event.sanitize(req.body.event));
+        return event.update(updates);
       })
       .then((event) => {
         res.json({ error: null, event: event.getPublic() });

--- a/app/api/v1/membership/event/index.js
+++ b/app/api/v1/membership/event/index.js
@@ -82,10 +82,10 @@ router
       .catch(next);
   })
   /**
-   * For all further requests on this route, the user needs to be an admin
+   * For all further requests on this route, the user needs to be an admin or officer
    */
   .all((req, res, next) => {
-    if (!req.user.isAdmin()) return next(new error.Forbidden());
+    if (!req.user.isAdmin() && !req.user.isOfficer()) return next(new error.Forbidden());
     return next();
   })
   /**
@@ -94,6 +94,18 @@ router
    */
   .post((req, res, next) => {
     if (!req.body.event) return next(new error.BadRequest());
+
+    if (!req.user.isAdmin()) {
+      if (!req.body.event.committee || !req.body.event.committee.trim()) {
+        return next(new error.Forbidden('You do not have permission to create events outside your committee.'));
+      }
+
+      try {
+        assertCanManageCommitteeResource(req.user, req.body.event.committee, 'event');
+      } catch (err) {
+        return next(err);
+      }
+    }
 
     if (
       req.body.event.startDate

--- a/app/api/v1/membership/event/index.js
+++ b/app/api/v1/membership/event/index.js
@@ -55,6 +55,8 @@ router
   .get((req, res, next) => {
     if (req.user.isPending()) return next(new error.Forbidden());
 
+    const canViewAttendanceCode = req.user.isAdmin() || req.user.isOfficer();
+
     const offset = parseInt(req.query.offset, 10);
     const limit = parseInt(req.query.limit, 10);
     const { committee } = req.query;
@@ -75,7 +77,7 @@ router
 
         res.json({
           error: null,
-          events: events.map((e) => e.getPublic(req.user.isAdmin())),
+          events: events.map((e) => e.getPublic(canViewAttendanceCode)),
         });
         return null;
       })
@@ -119,7 +121,9 @@ router
 
     return Event.create(Event.sanitize(req.body.event))
       .then((event) => {
-        res.json({ error: null, event: event.getPublic() });
+        res.json(
+          { error: null, event: event.getPublic(req.user.isAdmin() || req.user.isOfficer()) },
+        );
         return null;
       })
       .catch(next);
@@ -131,6 +135,8 @@ router
   .get((req, res, next) => {
     if (req.user.isPending()) return next(new error.Forbidden());
 
+    const canViewAttendanceCode = req.user.isAdmin() || req.user.isOfficer();
+
     // CASE: UUID is present, should return matching event
     return Event.findByUUID(req.params.uuid)
       .then((event) => {
@@ -138,7 +144,7 @@ router
         // an event was found. otherwise, return null
         res.json({
           error: null,
-          event: event ? event.getPublic(req.user.isAdmin()) : null,
+          event: event ? event.getPublic(canViewAttendanceCode) : null,
         });
         return null;
       })
@@ -185,7 +191,9 @@ router
         return event.update(updates);
       })
       .then((event) => {
-        res.json({ error: null, event: event.getPublic() });
+        res.json(
+          { error: null, event: event.getPublic(req.user.isAdmin() || req.user.isOfficer()) },
+        );
         return null;
       })
       .catch(next);
@@ -194,7 +202,7 @@ router
    * Delete an event given a UUID
    *
    * Returns the number of events deleted (1 if successful, 0 if event not found)
-   */
+     */
   .delete((req, res, next) => {
     if (!req.params.uuid) return next(new error.BadRequest());
 

--- a/app/api/v1/membership/image/index.js
+++ b/app/api/v1/membership/image/index.js
@@ -2,7 +2,11 @@ const express = require('express');
 const multer = require('multer');
 const error = require('../../../../error');
 const auth = require('../../auth').authenticated;
-const { Image } = require('../../../../db');
+const { Image, Event } = require('../../../../db');
+const {
+  canManageCommitteeResource,
+  findCommitteesByImageUUID,
+} = require('../../auth/committeeScope');
 
 const router = express.Router();
 
@@ -22,11 +26,31 @@ router
       .catch(next);
   })
   .all(auth, (req, res, next) => {
-    if (!req.user.isAdmin()) return next(new error.Forbidden());
+    if (!req.user.isAdmin() && !req.user.isOfficer()) return next(new error.Forbidden());
     return next();
   })
   .delete(auth, (req, res, next) => {
-    Image.destroyByUUID(req.params.uuid)
+    const { uuid } = req.params;
+    const guardByCommittee = req.user.isAdmin()
+      ? Promise.resolve()
+      : findCommitteesByImageUUID(Event, uuid)
+        .then((committees) => {
+          if (committees.length === 0) {
+            throw new error.Forbidden('You do not have permission to delete this image.');
+          }
+
+          // eslint-disable-next-line max-len
+          const allCommitteesAllowed = committees.every(
+            (committee) => canManageCommitteeResource(req.user, committee),
+          );
+
+          if (!allCommitteesAllowed) {
+            throw new error.Forbidden('You do not have permission to delete this image.');
+          }
+        });
+
+    guardByCommittee
+      .then(() => Image.destroyByUUID(uuid))
       .then(() => res.status(200).json({ error: null }))
       .catch((err) => {
         next(err);

--- a/app/api/v1/membership/image/index.js
+++ b/app/api/v1/membership/image/index.js
@@ -69,17 +69,18 @@ router
       })
       .catch(next);
   })
-  .all(auth, (req, res, next) => {
-    if (!req.user.isAdmin() && !req.user.isOfficer()) return next(new error.Forbidden());
-    return next();
-  })
   .post([auth, upload.single('image')], (req, res, next) => {
+    if (!req.user.isAdmin() && !req.user.isOfficer()) {
+      return next(new error.Forbidden());
+    }
+
     if (!req.file) return next(new error.BadRequest());
     const imageBuffer = req.file.buffer;
     const mimeType = req.file.mimetype;
+
     Image.create({ data: imageBuffer, mimetype: mimeType, size: imageBuffer.length })
       .then((image) => {
-        res.json({ error: null, uuid: image.uuid });
+        res.json({ error: null, uuid: image.getDataValue('uuid') });
       })
       .catch(next);
     return null; // eslint

--- a/app/api/v1/membership/image/index.js
+++ b/app/api/v1/membership/image/index.js
@@ -70,7 +70,7 @@ router
       .catch(next);
   })
   .all(auth, (req, res, next) => {
-    if (!req.user.isAdmin()) return next(new error.Forbidden());
+    if (!req.user.isAdmin() && !req.user.isOfficer()) return next(new error.Forbidden());
     return next();
   })
   .post([auth, upload.single('image')], (req, res, next) => {

--- a/app/api/v1/membership/rsvp/index.js
+++ b/app/api/v1/membership/rsvp/index.js
@@ -3,6 +3,7 @@ const error = require('../../../../error');
 const {
   Event, RSVP, User,
 } = require('../../../../db');
+const { canManageCommitteeResource } = require('../../auth/committeeScope');
 
 const router = express.Router();
 
@@ -21,35 +22,44 @@ router.route('/').get((req, res, next) => {
 });
 
 /**
- * Gets all RSVPs for a specific event (admin only)
+ * Gets all RSVPs for a specific event (admin or committee-scoped officer)
  * Returns a list of RSVP objects enriched with user profile data
  */
 router.route('/event/:uuid').get((req, res, next) => {
   if (req.user.isPending()) return next(new error.Forbidden());
 
-  // Only admins can access this endpoint
-  if (!req.user.isAdmin()) {
+  // Only admins and officers can access this endpoint.
+  if (!req.user.isAdmin() && !req.user.isOfficer()) {
     return next(new error.Forbidden());
   }
 
-  // Find all RSVP records for THAT EVENT and enrich with user profiles
-  return RSVP.getRSVPsForEvent(req.params.uuid)
-    .then((rsvps) => {
-      // Extract all user UUIDs from RSVPs
-      const userPromises = rsvps.map((rsvp) => User.findByUUID(rsvp.getDataValue('user')));
+  return Event.findByUUID(req.params.uuid)
+    .then((event) => {
+      if (!event) throw new error.UserError('Event not found');
 
-      // Fetch all users in parallel
-      return Promise.all(userPromises)
-        .then((users) => {
-          // Combine RSVP data with user profile data
-          const enrichedRsvps = rsvps.map((rsvp, index) => ({
-            uuid: rsvp.getDataValue('uuid'),
-            user: users[index] ? users[index].getUserProfile() : null,
-            event: rsvp.getDataValue('event'),
-            date: rsvp.getDataValue('date'),
-          }));
+      if (!req.user.isAdmin() && !canManageCommitteeResource(req.user, event.committee)) {
+        throw new error.Forbidden('You do not have permission to view RSVPs for this event.');
+      }
 
-          return res.json({ error: null, rsvps: enrichedRsvps });
+      // Find all RSVP records for THAT EVENT and enrich with user profiles
+      return RSVP.getRSVPsForEvent(req.params.uuid)
+        .then((rsvps) => {
+          // Extract all user UUIDs from RSVPs
+          const userPromises = rsvps.map((rsvp) => User.findByUUID(rsvp.getDataValue('user')));
+
+          // Fetch all users in parallel
+          return Promise.all(userPromises)
+            .then((users) => {
+              // Combine RSVP data with user profile data
+              const enrichedRsvps = rsvps.map((rsvp, index) => ({
+                uuid: rsvp.getDataValue('uuid'),
+                user: users[index] ? users[index].getUserProfile() : null,
+                event: rsvp.getDataValue('event'),
+                date: rsvp.getDataValue('date'),
+              }));
+
+              return res.json({ error: null, rsvps: enrichedRsvps });
+            });
         });
     })
     .catch(next);

--- a/tests/officer-delete-scope.test.js
+++ b/tests/officer-delete-scope.test.js
@@ -1,0 +1,163 @@
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const { server, setup } = require('..');
+const config = require('../app/config');
+const { User, Event, Image } = require('../app/db');
+
+const API_ROUTE = '/app/api/v1';
+
+const unique = (prefix) => `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+const makeToken = (user) => new Promise((resolve, reject) => {
+  jwt.sign(
+    {
+      uuid: user.getDataValue('uuid'),
+      admin: user.isAdmin(),
+      superAdmin: user.isSuperAdmin(),
+      officer: user.isOfficer(),
+      registered: !user.isPending(),
+    },
+    config.session.secret,
+    { expiresIn: 3600 },
+    (err, token) => {
+      if (err) return reject(err);
+      return resolve(token);
+    },
+  );
+});
+
+const createUser = async ({ accessType, committees = [] }) => User.create({
+  email: `${unique(accessType.toLowerCase())}@test.local`,
+  firstName: 'Test',
+  lastName: 'User',
+  accessType,
+  committees,
+  state: 'ACTIVE',
+  year: 3,
+  major: 'Computer Science',
+});
+
+const createEvent = async ({ committee, cover }) => Event.create({
+  committee,
+  title: unique(`Event-${committee}`),
+  description: 'Scoped deletion test event',
+  location: 'Boelter Hall',
+  eventLink: 'https://example.com/event',
+  startDate: new Date(Date.now() + 86400000),
+  endDate: new Date(Date.now() + 90000000),
+  attendanceCode: unique(`CODE-${committee}`),
+  attendancePoints: 1,
+  cover,
+});
+
+const createImage = async () => Image.create({
+  data: Buffer.from(unique('image-bytes')),
+  mimetype: 'image/png',
+  size: 16,
+});
+
+beforeAll(async () => {
+  await setup(false, true);
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('Committee-scoped delete authorization', () => {
+  test('Officer can delete event in assigned committee and is forbidden outside it', async () => {
+    const officer = await createUser({ accessType: 'OFFICER', committees: ['Hack'] });
+    const officerToken = await makeToken(officer);
+
+    const hackEvent = await createEvent({ committee: 'Hack', cover: 'https://example.com/hack.png' });
+    const aiEvent = await createEvent({ committee: 'AI', cover: 'https://example.com/ai.png' });
+
+    const allowedDelete = await request(server)
+      .delete(`${API_ROUTE}/event/${hackEvent.uuid}`)
+      .auth(officerToken, { type: 'bearer' });
+
+    expect(allowedDelete.statusCode).toBe(200);
+    expect(allowedDelete.body).toHaveProperty('numDeleted', 1);
+    expect(await Event.findByUUID(hackEvent.uuid)).toBeNull();
+
+    const forbiddenDelete = await request(server)
+      .delete(`${API_ROUTE}/event/${aiEvent.uuid}`)
+      .auth(officerToken, { type: 'bearer' });
+
+    expect(forbiddenDelete.statusCode).toBe(403);
+    expect(forbiddenDelete.body.error.message).toMatch(/permission/i);
+    expect(await Event.findByUUID(aiEvent.uuid)).not.toBeNull();
+
+    await Event.destroy({ where: { uuid: aiEvent.uuid } });
+    await User.destroy({ where: { uuid: officer.uuid } });
+  });
+
+  test('Admin can delete any event regardless of committee', async () => {
+    const admin = await createUser({ accessType: 'ADMIN' });
+    const adminToken = await makeToken(admin);
+
+    const designEvent = await createEvent({ committee: 'Design', cover: 'https://example.com/design.png' });
+
+    const deleteResponse = await request(server)
+      .delete(`${API_ROUTE}/event/${designEvent.uuid}`)
+      .auth(adminToken, { type: 'bearer' });
+
+    expect(deleteResponse.statusCode).toBe(200);
+    expect(deleteResponse.body).toHaveProperty('numDeleted', 1);
+    expect(await Event.findByUUID(designEvent.uuid)).toBeNull();
+
+    await User.destroy({ where: { uuid: admin.uuid } });
+  });
+
+  test('Officer can delete image tied to assigned committee and is forbidden outside it', async () => {
+    const officer = await createUser({ accessType: 'OFFICER', committees: ['Hack'] });
+    const officerToken = await makeToken(officer);
+
+    const hackImage = await createImage();
+    const aiImage = await createImage();
+
+    const hackCover = `http://localhost:8080/app/api/v1/image/raw/${hackImage.uuid}`;
+    const aiCover = `http://localhost:8080/app/api/v1/image/raw/${aiImage.uuid}`;
+
+    const hackEvent = await createEvent({ committee: 'Hack', cover: hackCover });
+    const aiEvent = await createEvent({ committee: 'AI', cover: aiCover });
+
+    const allowedDelete = await request(server)
+      .delete(`${API_ROUTE}/image/raw/${hackImage.uuid}`)
+      .auth(officerToken, { type: 'bearer' });
+
+    expect(allowedDelete.statusCode).toBe(200);
+    expect((await Image.getImage(hackImage.uuid)).length).toBe(0);
+
+    const forbiddenDelete = await request(server)
+      .delete(`${API_ROUTE}/image/raw/${aiImage.uuid}`)
+      .auth(officerToken, { type: 'bearer' });
+
+    expect(forbiddenDelete.statusCode).toBe(403);
+    expect(forbiddenDelete.body.error.message).toMatch(/permission/i);
+    expect((await Image.getImage(aiImage.uuid)).length).toBe(1);
+
+    await Event.destroy({ where: { uuid: [hackEvent.uuid, aiEvent.uuid] } });
+    await Image.destroy({ where: { uuid: aiImage.uuid } });
+    await User.destroy({ where: { uuid: officer.uuid } });
+  });
+
+  test('Admin can delete any image regardless of committee', async () => {
+    const admin = await createUser({ accessType: 'ADMIN' });
+    const adminToken = await makeToken(admin);
+
+    const image = await createImage();
+    const cover = `http://localhost:8080/app/api/v1/image/raw/${image.uuid}`;
+    const event = await createEvent({ committee: 'Cyber', cover });
+
+    const deleteResponse = await request(server)
+      .delete(`${API_ROUTE}/image/raw/${image.uuid}`)
+      .auth(adminToken, { type: 'bearer' });
+
+    expect(deleteResponse.statusCode).toBe(200);
+    expect((await Image.getImage(image.uuid)).length).toBe(0);
+
+    await Event.destroy({ where: { uuid: event.uuid } });
+    await User.destroy({ where: { uuid: admin.uuid } });
+  });
+});


### PR DESCRIPTION
Summary: Committee-Scoped Authorization
Implemented granular access control for Events, RSVPs, and Images to ensure Officers only manage resources within their assigned committees.

Resolves #125 

Rules
1. Event Deletion (DELETE /events)

Admin: Full access to delete any event.
Officer: Can only delete if the event.committee matches their assigned committees.
Others: Access forbidden.

2. RSVP Access (GET /api/v1/rsvp/event/:uuid)

Admin: Can view RSVPs for any event.
Officer: Restricted to viewing RSVPs for events within their committees.
Others: Access forbidden.

3. Image Management (DELETE /images)

Admin: Full access to delete any image.
Officer: Strict Validation — Deletion is only allowed if all committees linked to the image UUID are within the officer's managed committees.

Other: Access forbidden.