### PR TITLE
Action: Create Admin Committee Discovery Endpoint #139

### DIFF
--- a/app/api/v1/internship/controllers/committeeController.js
+++ b/app/api/v1/internship/controllers/committeeController.js
@@ -91,8 +91,21 @@ async function deleteCommittee(req, res, next) {
   }
 }
 
+async function getAllCommitteesAdmin(req, res, next) {
+  try {
+    const committees = await Committee
+      .find({})
+      .sort({ displayName: 1 });
+
+    return res.json({ error: null, committees });
+  } catch (error) {
+    return next(error);
+  }
+}
+
 module.exports = {
   getAllCommittees,
+  getAllCommitteesAdmin,
   getCommitteeById,
   createCommittees,
   updateCommittee,

--- a/app/api/v1/internship/index.js
+++ b/app/api/v1/internship/index.js
@@ -15,6 +15,7 @@ const {
 } = require('./controllers/applicationController');
 const {
   getAllCommittees,
+  getAllCommitteesAdmin,
   getCommitteeById,
   createCommittees,
   updateCommittee,
@@ -46,6 +47,9 @@ router.delete('/applications/:id', auth, deleteApplication);
 
 // GET all committees
 router.get('/committees', getAllCommittees);
+
+// GET all committees including inactive (admin only) - must be before /:id
+router.get('/committees/admin', auth, admin, getAllCommitteesAdmin);
 
 // GET a single committee by ID
 router.get('/committees/:id', auth, getCommitteeById);


### PR DESCRIPTION
## Description

Implement a privileged endpoint to retrieve the complete list of internship committees. Unlike the public fetch action, this endpoint bypasses status filters to allow administrators to view, audit, and manage inactive or archived committees within the admin panel.

## Related Issue

Resolves #139

## Steps to view & test changes

- Log in locally and make your account admin via `UPDATE users SET "accessType" = 'ADMIN' WHERE email = '<your-email>';` in the Docker postgres container
- Call `GET /app/api/v1/internship/committees/admin` with a valid admin session token
- Verify it returns `{ error: null, committees: [...] }` including inactive committees
- Verify a non-admin token receives `403 Forbidden`
- Verify the public `GET /app/api/v1/internship/committees` still works without auth and only returns active committees

## How Has This Been Tested?

- [x] Manual tests
- [ ]  Responsive View

## Screenshots (if appropriate)

N/A