### PR TITLE
Added Application Submission Endpoint

### DIFF
--- a/app/api/v1/internship/controllers/applicationController.js
+++ b/app/api/v1/internship/controllers/applicationController.js
@@ -4,6 +4,24 @@ const {
 } = require('../models/InternshipApplication');
 const { Committee } = require('../models/Committee');
 
+const CHOICE_FIELDS = [
+  {
+    label: 'first choice',
+    committeeField: 'firstChoiceCommittee',
+    responsesField: 'firstChoiceResponses',
+  },
+  {
+    label: 'second choice',
+    committeeField: 'secondChoiceCommittee',
+    responsesField: 'secondChoiceResponses',
+  },
+  {
+    label: 'third choice',
+    committeeField: 'thirdChoiceCommittee',
+    responsesField: 'thirdChoiceResponses',
+  },
+];
+
 // Create a new internship application
 async function createApplication(req, res) {
   try {
@@ -404,6 +422,110 @@ async function deleteApplication(req, res) {
   }
 }
 
+// Submit a draft application after validating ownership, state, committees,
+// deadlines, and completeness of required question answers.
+async function submitApplication(req, res) {
+  try {
+    const application = await InternshipApplication.findById(req.params.id);
+
+    if (!application || application.deletedAt) {
+      return res.status(404).json({
+        success: false,
+        message: 'Application not found',
+      });
+    }
+
+    if (application.userId !== req.user.uuid) {
+      return res.status(403).json({
+        success: false,
+        message: 'You do not have permission to submit this application',
+      });
+    }
+
+    if (application.submissionStatus !== 'draft') {
+      return res.status(409).json({
+        success: false,
+        message: 'Application has already been submitted',
+      });
+    }
+
+    const selectedChoices = CHOICE_FIELDS
+      .map((choice) => ({ ...choice, committeeId: application[choice.committeeField] }))
+      .filter((choice) => choice.committeeId);
+
+    if (selectedChoices.length === 0) {
+      return res.status(400).json({
+        success: false,
+        message: 'Application must include at least one committee selection',
+      });
+    }
+
+    const committeeIds = selectedChoices.map((c) => c.committeeId);
+    const committees = await Committee.find({ _id: { $in: committeeIds } });
+    const committeeById = new Map(committees.map((c) => [c._id.toString(), c]));
+
+    const now = Date.now();
+
+    for (let i = 0; i < selectedChoices.length; i++) {
+      const { label, committeeId, responsesField } = selectedChoices[i];
+      const committee = committeeById.get(committeeId.toString());
+
+      if (!committee) {
+        return res.status(400).json({
+          success: false,
+          message: `${label} committee no longer exists`,
+        });
+      }
+
+      if (!committee.isActive) {
+        return res.status(400).json({
+          success: false,
+          message: `${label} committee is no longer accepting applications`,
+        });
+      }
+
+      if (!committee.applicationDeadline
+        || new Date(committee.applicationDeadline).getTime() <= now) {
+        return res.status(400).json({
+          success: false,
+          message: `${label} committee application deadline has passed`,
+        });
+      }
+
+      const requiredQuestions = committee.customQuestions.filter((q) => q.required);
+      const responses = application[responsesField] || [];
+      const answersByKey = new Map(
+        responses.map((r) => [r.questionKey, (r.answer || '').trim()]),
+      );
+
+      const missing = requiredQuestions.filter((q) => !answersByKey.get(q.questionKey));
+
+      if (missing.length > 0) {
+        const missingNames = missing.map((q) => q.questionText).join(', ');
+        return res.status(400).json({
+          success: false,
+          message: `Missing required answers for ${label} committee: ${missingNames}`,
+        });
+      }
+    }
+
+    application.submissionStatus = 'submitted';
+    application.submittedAt = Date.now();
+    await application.save();
+
+    return res.status(200).json({
+      success: true,
+      data: application,
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: 'Error submitting application',
+      error: error.message,
+    });
+  }
+}
+
 module.exports = {
   createApplication,
   getAllApplications,
@@ -411,4 +533,5 @@ module.exports = {
   updateApplication,
   deleteApplication,
   getOwnApplication,
+  submitApplication,
 };

--- a/app/api/v1/internship/index.js
+++ b/app/api/v1/internship/index.js
@@ -12,6 +12,7 @@ const {
   updateApplication,
   deleteApplication,
   getOwnApplication,
+  submitApplication,
 } = require('./controllers/applicationController');
 const {
   getAllCommittees,
@@ -20,7 +21,12 @@ const {
   updateCommittee,
   deleteCommittee,
 } = require('./controllers/committeeController');
-const { validateCreateApplication, validateUpdateApplication, validateGetApplications } = require('./middleware/validation');
+const {
+  validateCreateApplication,
+  validateUpdateApplication,
+  validateGetApplications,
+  validateMongoId,
+} = require('./middleware/validation');
 const { strictCreateApplicationLimiter, getApplicationsLimiter, committeeRateLimiter } = require('./middleware/rateLimiter');
 
 const router = express.Router();
@@ -40,6 +46,9 @@ router.post('/applications', auth, strictCreateApplicationLimiter, validateCreat
 
 // PUT (update) an application by ID
 router.put('/applications/:id', auth, validateUpdateApplication, updateApplication);
+
+// POST submit a draft application (member+)
+router.post('/applications/:id/submit', auth, strictCreateApplicationLimiter, validateMongoId, submitApplication);
 
 // DELETE an application by ID
 router.delete('/applications/:id', auth, deleteApplication);

--- a/tests/submitApplication.test.js
+++ b/tests/submitApplication.test.js
@@ -1,0 +1,223 @@
+jest.mock('../app/api/v1/internship/models/InternshipApplication', () => ({
+  InternshipApplication: {
+    findById: jest.fn(),
+  },
+  getCurrentApplicationCycle: jest.fn(() => '2026-2027'),
+}));
+
+jest.mock('../app/api/v1/internship/models/Committee', () => ({
+  Committee: {
+    find: jest.fn(),
+  },
+}));
+
+const { submitApplication } = require('../app/api/v1/internship/controllers/applicationController');
+const { InternshipApplication } = require('../app/api/v1/internship/models/InternshipApplication');
+const { Committee } = require('../app/api/v1/internship/models/Committee');
+
+const OWNER_UUID = 'owner-uuid';
+const APPLICATION_ID = 'app-1';
+const FIRST_COMMITTEE_ID = 'cmt-first';
+const SECOND_COMMITTEE_ID = 'cmt-second';
+
+function mockRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+}
+
+function buildApplication(overrides = {}) {
+  const app = {
+    _id: APPLICATION_ID,
+    userId: OWNER_UUID,
+    submissionStatus: 'draft',
+    firstChoiceCommittee: { toString: () => FIRST_COMMITTEE_ID },
+    secondChoiceCommittee: null,
+    thirdChoiceCommittee: null,
+    firstChoiceResponses: [{ questionKey: 'why', answer: 'Because I love it' }],
+    secondChoiceResponses: [],
+    thirdChoiceResponses: [],
+    save: jest.fn().mockImplementation(async function save() { return this; }),
+    ...overrides,
+  };
+  return app;
+}
+
+function buildCommittee(id, overrides = {}) {
+  return {
+    _id: { toString: () => id },
+    isActive: true,
+    applicationDeadline: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    customQuestions: [
+      { questionKey: 'why', questionText: 'Why?', required: true },
+    ],
+    ...overrides,
+  };
+}
+
+describe('submitApplication controller', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rejects with 404 when application does not exist', async () => {
+    InternshipApplication.findById.mockResolvedValue(null);
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+  });
+
+  test('rejects with 404 when application is soft-deleted', async () => {
+    InternshipApplication.findById.mockResolvedValue(
+      buildApplication({ deletedAt: new Date() }),
+    );
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  test('rejects with 403 when caller does not own the application', async () => {
+    InternshipApplication.findById.mockResolvedValue(buildApplication({ userId: 'someone-else' }));
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('rejects with 409 when application is already submitted', async () => {
+    InternshipApplication.findById.mockResolvedValue(
+      buildApplication({ submissionStatus: 'submitted' }),
+    );
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+
+  test('rejects with 400 when no committee is selected', async () => {
+    InternshipApplication.findById.mockResolvedValue(
+      buildApplication({ firstChoiceCommittee: null }),
+    );
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  test('rejects with 400 when a selected committee is inactive', async () => {
+    InternshipApplication.findById.mockResolvedValue(buildApplication());
+    Committee.find.mockResolvedValue([
+      buildCommittee(FIRST_COMMITTEE_ID, { isActive: false }),
+    ]);
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringMatching(/no longer accepting/i) }),
+    );
+  });
+
+  test('rejects with 400 when a committee deadline has passed', async () => {
+    InternshipApplication.findById.mockResolvedValue(buildApplication());
+    Committee.find.mockResolvedValue([
+      buildCommittee(FIRST_COMMITTEE_ID, {
+        applicationDeadline: new Date(Date.now() - 60 * 1000),
+      }),
+    ]);
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringMatching(/deadline has passed/i) }),
+    );
+  });
+
+  test('rejects with 400 when required question is missing an answer', async () => {
+    InternshipApplication.findById.mockResolvedValue(
+      buildApplication({ firstChoiceResponses: [{ questionKey: 'why', answer: '   ' }] }),
+    );
+    Committee.find.mockResolvedValue([buildCommittee(FIRST_COMMITTEE_ID)]);
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringMatching(/missing required answers/i) }),
+    );
+  });
+
+  test('rejects when a required answer is omitted entirely', async () => {
+    InternshipApplication.findById.mockResolvedValue(
+      buildApplication({ firstChoiceResponses: [] }),
+    );
+    Committee.find.mockResolvedValue([buildCommittee(FIRST_COMMITTEE_ID)]);
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  test('validates every selected committee, not only the first', async () => {
+    InternshipApplication.findById.mockResolvedValue(buildApplication({
+      secondChoiceCommittee: { toString: () => SECOND_COMMITTEE_ID },
+      secondChoiceResponses: [{ questionKey: 'why', answer: 'ok' }],
+    }));
+    Committee.find.mockResolvedValue([
+      buildCommittee(FIRST_COMMITTEE_ID),
+      buildCommittee(SECOND_COMMITTEE_ID, { isActive: false }),
+    ]);
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringMatching(/second choice/i) }),
+    );
+  });
+
+  test('transitions to submitted and stamps submittedAt when all guards pass', async () => {
+    const application = buildApplication();
+    InternshipApplication.findById.mockResolvedValue(application);
+    Committee.find.mockResolvedValue([buildCommittee(FIRST_COMMITTEE_ID)]);
+    const req = { params: { id: APPLICATION_ID }, user: { uuid: OWNER_UUID } };
+    const res = mockRes();
+
+    const before = Date.now();
+    await submitApplication(req, res);
+    const after = Date.now();
+
+    expect(application.submissionStatus).toBe('submitted');
+    expect(application.submittedAt).toBeGreaterThanOrEqual(before);
+    expect(application.submittedAt).toBeLessThanOrEqual(after);
+    expect(application.save).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: application });
+  });
+
+});


### PR DESCRIPTION
## Description

- Adds `POST /api/v1/internship/applications/:id/submit` — a one-way draft → submitted transition
- Guards: ownership, state (`submissionStatus === 'draft'`), soft-delete, every selected committee is active, every deadline is future, required answers non-empty                                                                                       
- On success: sets `submissionStatus = 'submitted'`, `submittedAt = Date.now()`, returns `{ success: true, data: application }`                                                                                                                          

## Related Issue

Resolves #134 

## Steps to view & test changes                                                                                                                                                                                                                                                         
- Run the unit tests:
npm test -- tests/submitApplication.test.js                                                                                                                                                                                                           
  
## How Has This Been Tested?

- [x] Manual tests
- [ ]  Responsive View

## Screenshots (if appropriate)

N/A