### PR TITLE
Feat/split update committe into two

### DIFF
--- a/app/api/v1/internship/controllers/committeeController.js
+++ b/app/api/v1/internship/controllers/committeeController.js
@@ -1,4 +1,6 @@
 const { Committee } = require('../models/Committee');
+const { canManageCommitteeResource } = require('../../auth/committeeScope');
+const error = require('../../../../error');
 
 async function getAllCommittees(req, res, next) {
   try {
@@ -36,7 +38,35 @@ async function createCommittees(req, res, next) {
   }
 }
 
-async function updateCommittee(req, res, next) {
+async function updateCommitteeQuestions(req, res, next) {
+  try {
+    const committee = await Committee.findById(req.params.id);
+    if(!committee) {
+      return res.status(404).json({error: "Committee not found"});
+    }
+    if(!canManageCommitteeResource(req.user, committee.name)) {
+      throw new error.Forbidden('You are not assigned to this committee.');
+    }
+
+    const { customQuestions } = req.body
+    if(!Array.isArray(customQuestions)) {
+      throw new error.BadRequest('customQuestions must be an array.');
+    }
+
+    const updatedCommittee = await Committee.findByIdAndUpdate(
+      req.params.id,
+      { $set: {customQuestions } },
+      { new: true, runValidators: true },
+    );
+
+    return res.json({ error: null, committee: updatedCommittee });
+  } catch (e) {
+    return next(e);
+  }
+}
+
+
+async function updateCommitteeAdmin(req, res, next) {
   try {
     const updatedCommittee = await Committee.findByIdAndUpdate(
       req.params.id,
@@ -46,7 +76,7 @@ async function updateCommittee(req, res, next) {
     if (!updatedCommittee) {
       return res.status(404).json({ error: 'Committee not found' });
     }
-    return res.json({ error: null, updatedCommittee });
+    return res.json({ error: null, committee: updatedCommittee });
   } catch (error) {
     return next(error);
   }
@@ -72,6 +102,7 @@ module.exports = {
   getAllCommittees,
   getCommitteeById,
   createCommittees,
-  updateCommittee,
+  updateCommitteeQuestions,
+  updateCommitteeAdmin,
   deleteCommittee,
 };

--- a/app/api/v1/internship/index.js
+++ b/app/api/v1/internship/index.js
@@ -17,7 +17,8 @@ const {
   getAllCommittees,
   getCommitteeById,
   createCommittees,
-  updateCommittee,
+  updateCommitteeQuestions,
+  updateCommitteeAdmin,
   deleteCommittee,
 } = require('./controllers/committeeController');
 const { validateCreateApplication, validateUpdateApplication, validateGetApplications } = require('./middleware/validation');
@@ -54,7 +55,11 @@ router.get('/committees/:id', auth, getCommitteeById);
 router.post('/committees', auth, admin, committeeRateLimiter, createCommittees);
 
 // UPDATE committee (admin only)
-router.put('/committees/:id', auth, admin, committeeRateLimiter, updateCommittee);
+router.put('/committees/:id/admin', auth, admin, committeeRateLimiter, updateCommitteeAdmin);
+
+// UPDATE committee (admin or officer)
+// Only allows updating committee questions
+router.put('/committees/:id/questions', auth, adminOrOfficer, committeeRateLimiter, updateCommitteeQuestions);
 
 // DELETE committee (admin only) - soft delete by setting isActive to false
 router.delete('/committees/:id', auth, admin, deleteCommittee);

--- a/tests/committee-endpoints.test.js
+++ b/tests/committee-endpoints.test.js
@@ -1,0 +1,245 @@
+jest.mock('google-auth-library', () => ({
+  OAuth2Client: jest.fn().mockImplementation(() => ({
+    verifyIdToken: jest.fn(),
+  })),
+}), { virtual: true });
+
+jest.mock('../app/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  log: jest.fn(),
+}));
+
+jest.mock('../app/api/v1/internship/models/Committee', () => ({
+  Committee: {
+    findById: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+  },
+}));
+
+const { Committee } = require('../app/api/v1/internship/models/Committee');
+const {
+  updateCommitteeQuestions,
+  updateCommitteeAdmin,
+} = require('../app/api/v1/internship/controllers/committeeController');
+const { isAdmin } = require('../app/api/v1/auth');
+const error = require('../app/error');
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const adminUser = {
+  isAdmin: () => true,
+  isOfficer: () => false,
+  hasCommittee: () => false,
+};
+
+const officerInHack = {
+  isAdmin: () => false,
+  isOfficer: () => true,
+  hasCommittee: (c) => c === 'Hack',
+};
+
+const officerInAI = {
+  isAdmin: () => false,
+  isOfficer: () => true,
+  hasCommittee: (c) => c === 'AI',
+};
+
+const sampleQuestions = [
+  { questionKey: 'why', questionText: 'Why apply?', questionType: 'long_text' },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('updateCommitteeQuestions (officer-scoped)', () => {
+  test('admin can update questions on any committee and receives the updated doc', async () => {
+    const committeeDoc = { _id: '1', name: 'Hack' };
+    const updated = { _id: '1', name: 'Hack', customQuestions: sampleQuestions };
+    Committee.findById.mockResolvedValue(committeeDoc);
+    Committee.findByIdAndUpdate.mockResolvedValue(updated);
+
+    const req = { params: { id: '1' }, user: adminUser, body: { customQuestions: sampleQuestions } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await updateCommitteeQuestions(req, res, next);
+
+    expect(Committee.findByIdAndUpdate).toHaveBeenCalledWith(
+      '1',
+      { $set: { customQuestions: sampleQuestions } },
+      expect.objectContaining({ new: true, runValidators: true }),
+    );
+    expect(res.json).toHaveBeenCalledWith({ error: null, committee: updated });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('officer assigned to the committee can update its questions', async () => {
+    const committeeDoc = { _id: '1', name: 'Hack' };
+    const updated = { _id: '1', name: 'Hack', customQuestions: sampleQuestions };
+    Committee.findById.mockResolvedValue(committeeDoc);
+    Committee.findByIdAndUpdate.mockResolvedValue(updated);
+
+    const req = { params: { id: '1' }, user: officerInHack, body: { customQuestions: sampleQuestions } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await updateCommitteeQuestions(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith({ error: null, committee: updated });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('officer in a different committee is forbidden with a descriptive 403', async () => {
+    Committee.findById.mockResolvedValue({ _id: '1', name: 'Hack' });
+
+    const req = { params: { id: '1' }, user: officerInAI, body: { customQuestions: sampleQuestions } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await updateCommitteeQuestions(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const passed = next.mock.calls[0][0];
+    expect(passed).toBeInstanceOf(error.Forbidden);
+    expect(passed.status).toBe(403);
+    expect(passed.message).toMatch(/not assigned/i);
+    expect(Committee.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('returns 404 when the committee does not exist', async () => {
+    Committee.findById.mockResolvedValue(null);
+
+    const req = { params: { id: 'missing' }, user: adminUser, body: { customQuestions: sampleQuestions } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await updateCommitteeQuestions(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Committee not found' });
+    expect(Committee.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 when customQuestions is missing or not an array', async () => {
+    Committee.findById.mockResolvedValue({ _id: '1', name: 'Hack' });
+
+    const req = { params: { id: '1' }, user: adminUser, body: { notQuestions: 'oops' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await updateCommitteeQuestions(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const passed = next.mock.calls[0][0];
+    expect(passed).toBeInstanceOf(error.BadRequest);
+    expect(passed.status).toBe(400);
+    expect(Committee.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('ignores attempts to change applicationDeadline, isActive, or other protected fields', async () => {
+    const committeeDoc = { _id: '1', name: 'Hack' };
+    const updated = { _id: '1', name: 'Hack', customQuestions: sampleQuestions };
+    Committee.findById.mockResolvedValue(committeeDoc);
+    Committee.findByIdAndUpdate.mockResolvedValue(updated);
+
+    const req = {
+      params: { id: '1' },
+      user: adminUser,
+      body: {
+        customQuestions: sampleQuestions,
+        applicationDeadline: new Date('2030-01-01'),
+        isActive: false,
+        name: 'get hacked nerd',
+        internLimit: 999,
+      },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await updateCommitteeQuestions(req, res, next);
+
+    expect(Committee.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+    const [, updatePayload] = Committee.findByIdAndUpdate.mock.calls[0];
+    expect(updatePayload).toEqual({ $set: { customQuestions: sampleQuestions } });
+    expect(updatePayload.$set).not.toHaveProperty('applicationDeadline');
+    expect(updatePayload.$set).not.toHaveProperty('isActive');
+    expect(updatePayload.$set).not.toHaveProperty('name');
+    expect(updatePayload.$set).not.toHaveProperty('internLimit');
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateCommitteeAdmin', () => {
+  test('admin can update name, internLimit, isActive, and applicationDeadline together', async () => {
+    const update = {
+      name: 'ACM Hack',
+      internLimit: 20,
+      isActive: false,
+      applicationDeadline: new Date('2026-4-20'),
+    };
+    const updated = { _id: '1', ...update };
+    Committee.findByIdAndUpdate.mockResolvedValue(updated);
+
+    const req = { params: { id: '1' }, user: adminUser, body: update };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await updateCommitteeAdmin(req, res, next);
+
+    expect(Committee.findByIdAndUpdate).toHaveBeenCalledWith(
+      '1',
+      update,
+      expect.objectContaining({ new: true, runValidators: true }),
+    );
+    expect(res.json).toHaveBeenCalledWith({ error: null, committee: updated });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 404 when the committee does not exist', async () => {
+    Committee.findByIdAndUpdate.mockResolvedValue(null);
+
+    const req = { params: { id: 'missing' }, user: adminUser, body: { name: 'x' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await updateCommitteeAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Committee not found' });
+  });
+});
+
+describe('isAdmin middleware — gates PUT /committees/:id/admin', () => {
+  test('admin is allowed through', () => {
+    const next = jest.fn();
+    isAdmin({ user: adminUser }, mockRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  test('officer (non-admin) is blocked with 403', () => {
+    const next = jest.fn();
+    isAdmin({ user: officerInHack }, mockRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const passed = next.mock.calls[0][0];
+    expect(passed).toBeInstanceOf(error.Forbidden);
+    expect(passed.status).toBe(403);
+  });
+
+  test('unauthenticated request (no req.user) is blocked with 403', () => {
+    const next = jest.fn();
+    isAdmin({}, mockRes(), next);
+    const passed = next.mock.calls[0][0];
+    expect(passed).toBeInstanceOf(error.Forbidden);
+    expect(passed.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Description

Splits `PUT /api/v1/internship/committees/:id` into two endpoints: one for admins with full write access, one for admins or officers that is scoped to updating application questions (only to their committee).

- `PUT /api/v1/internship/committees/:id/admin`: admin only. Updates any field on the committee (name, internLimit, isActive, applicationDeadline, etc)
- `PUT /api/v1/internship/committees/:id/questions`: admin or officer. Officers must be assigned to the target committee. Only `customQuestions` can be updated, other body fields are ignored
- The old `PUT /api/v1/internship/committees/:id` route was removed
- Adds `tests/committee-endpoints.test.js` with unit tests covering both controllers and the `isAdmin` middleware gate
- Replaces the `updateCommittee` merged in #133: uses route-level middleware and the shared `canManageCommitteeResource` helper instead of runtime role branching

## Related Issue

Resolves #137 

## Steps to view & test changes:

- Run make test to run the Jest suite, including the new tests/committee-endpoints.test.js
- Run make to start the dev containers and hit the two endpoints with curl against `localhost:8080/app/api/v1/internship/committees/:id/admin` and `/:id/questions`

## How Has This Been Tested?

- [x] Unit tests
- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)

N/A