### PR TITLE
feat: update app submission endpoint and created app status update endpoint

### DIFF
--- a/app/api/v1/internship/controllers/applicationController.js
+++ b/app/api/v1/internship/controllers/applicationController.js
@@ -360,9 +360,6 @@ async function updateApplication(req, res) {
       'firstChoiceResponses',
       'secondChoiceResponses',
       'thirdChoiceResponses',
-      'firstChoiceStatus',
-      'secondChoiceStatus',
-      'thirdChoiceStatus',
     ];
 
     // Fetch the application to check ownership and status
@@ -587,7 +584,7 @@ async function submitApplication(req, res) {
     const committeeIds = selectedChoices.map((c) => c.committeeId);
     const committees = await Committee.find({ _id: { $in: committeeIds } })
       .select('isActive applicationDeadline customQuestions displayName name');
-    const committeeById = new Map(committees.map((c) => [c._id.toString(), c]));
+    const committeeById = new Map(committees.map((c) => [c.id.toString(), c]));
 
     const expiredCommittees = findCommitteesPastDeadline(committees);
     if (expiredCommittees.length > 0) {

--- a/app/api/v1/internship/controllers/applicationController.js
+++ b/app/api/v1/internship/controllers/applicationController.js
@@ -3,24 +3,62 @@ const {
   getCurrentApplicationCycle,
 } = require('../models/InternshipApplication');
 const { Committee } = require('../models/Committee');
+const {
+  buildDeadlineViolationMessage,
+  findCommitteesPastDeadline,
+  getCommitteeLabel,
+} = require('../utils/deadlineValidation');
 
 const CHOICE_FIELDS = [
   {
     label: 'first choice',
     committeeField: 'firstChoiceCommittee',
     responsesField: 'firstChoiceResponses',
+    statusField: 'firstChoiceStatus',
   },
   {
     label: 'second choice',
     committeeField: 'secondChoiceCommittee',
     responsesField: 'secondChoiceResponses',
+    statusField: 'secondChoiceStatus',
   },
   {
     label: 'third choice',
     committeeField: 'thirdChoiceCommittee',
     responsesField: 'thirdChoiceResponses',
+    statusField: 'thirdChoiceStatus',
   },
 ];
+
+function getOfficerCommittees(user) {
+  if (!user) {
+    return [];
+  }
+  if (user.getDataValue) {
+    return user.getDataValue('committees') || [];
+  }
+  return user.committees || [];
+}
+
+function normalizeCommitteeName(name) {
+  return typeof name === 'string' ? name.trim().toLowerCase() : '';
+}
+
+function officerCanManageCommittee(user, committee) {
+  const officerCommittees = getOfficerCommittees(user)
+    .map(normalizeCommitteeName)
+    .filter(Boolean);
+  const committeeNames = [
+    committee && committee.name,
+    committee && committee.displayName,
+  ].map(normalizeCommitteeName).filter(Boolean);
+
+  return committeeNames.some((name) => officerCommittees.includes(name));
+}
+
+function buildMissingFieldsMessage(missingFields) {
+  return `Missing required fields: ${missingFields.join(', ')}`;
+}
 
 // Create a new internship application
 async function createApplication(req, res) {
@@ -422,6 +460,92 @@ async function deleteApplication(req, res) {
   }
 }
 
+// Update review status for one committee choice on a submitted application.
+async function updateApplicationStatus(req, res) {
+  try {
+    const { statusField, status } = req.body;
+    const choice = CHOICE_FIELDS.find((item) => item.statusField === statusField);
+
+    if (!choice) {
+      return res.status(400).json({
+        success: false,
+        message: 'Invalid status field',
+      });
+    }
+
+    const application = await InternshipApplication.findById(req.params.id);
+    if (!application || application.deletedAt) {
+      return res.status(404).json({
+        success: false,
+        message: 'Application not found',
+      });
+    }
+
+    if (application.submissionStatus !== 'submitted') {
+      return res.status(400).json({
+        success: false,
+        message: 'Application status can only be updated after submission',
+      });
+    }
+
+    const committeeId = application[choice.committeeField];
+    if (!committeeId) {
+      return res.status(400).json({
+        success: false,
+        message: `Application does not include a ${choice.label} committee`,
+      });
+    }
+
+    const committee = await Committee.findById(committeeId)
+      .select('name displayName');
+    if (!committee) {
+      return res.status(400).json({
+        success: false,
+        message: `${choice.label} committee no longer exists`,
+      });
+    }
+
+    const isAdmin = typeof req.user.isAdmin === 'function' && req.user.isAdmin();
+    const isOfficer = typeof req.user.isOfficer === 'function' && req.user.isOfficer();
+
+    if (!isAdmin && (!isOfficer || !officerCanManageCommittee(req.user, committee))) {
+      return res.status(403).json({
+        success: false,
+        message: `You do not have permission to update ${choice.label} status`,
+      });
+    }
+
+    const lastModifiedAt = new Date();
+    const updatedApp = await InternshipApplication.findByIdAndUpdate(
+      req.params.id,
+      {
+        [statusField]: status,
+        lastModifiedAt,
+      },
+      { new: true, runValidators: true },
+    );
+
+    return res.status(200).json({
+      success: true,
+      data: updatedApp,
+      message: 'Application status updated successfully',
+    });
+  } catch (error) {
+    if (error.name === 'ValidationError') {
+      return res.status(400).json({
+        success: false,
+        message: 'Validation error',
+        errors: error.errors,
+      });
+    }
+    return res.status(500).json({
+      success: false,
+      message: 'Error updating application status',
+      error: error.message,
+    });
+  }
+}
+
 // Submit a draft application after validating ownership, state, committees,
 // deadlines, and completeness of required question answers.
 async function submitApplication(req, res) {
@@ -443,7 +567,7 @@ async function submitApplication(req, res) {
     }
 
     if (application.submissionStatus !== 'draft') {
-      return res.status(409).json({
+      return res.status(400).json({
         success: false,
         message: 'Application has already been submitted',
       });
@@ -461,10 +585,17 @@ async function submitApplication(req, res) {
     }
 
     const committeeIds = selectedChoices.map((c) => c.committeeId);
-    const committees = await Committee.find({ _id: { $in: committeeIds } });
+    const committees = await Committee.find({ _id: { $in: committeeIds } })
+      .select('isActive applicationDeadline customQuestions displayName name');
     const committeeById = new Map(committees.map((c) => [c._id.toString(), c]));
 
-    const now = Date.now();
+    const expiredCommittees = findCommitteesPastDeadline(committees);
+    if (expiredCommittees.length > 0) {
+      return res.status(400).json({
+        success: false,
+        message: buildDeadlineViolationMessage(expiredCommittees),
+      });
+    }
 
     for (let i = 0; i < selectedChoices.length; i++) {
       const { label, committeeId, responsesField } = selectedChoices[i];
@@ -484,14 +615,6 @@ async function submitApplication(req, res) {
         });
       }
 
-      if (!committee.applicationDeadline
-        || new Date(committee.applicationDeadline).getTime() <= now) {
-        return res.status(400).json({
-          success: false,
-          message: `${label} committee application deadline has passed`,
-        });
-      }
-
       const requiredQuestions = committee.customQuestions.filter((q) => q.required);
       const responses = application[responsesField] || [];
       const answersByKey = new Map(
@@ -501,21 +624,43 @@ async function submitApplication(req, res) {
       const missing = requiredQuestions.filter((q) => !answersByKey.get(q.questionKey));
 
       if (missing.length > 0) {
-        const missingNames = missing.map((q) => q.questionText).join(', ');
+        const missingNames = missing
+          .map((q) => `${getCommitteeLabel(committee)}: ${q.questionText}`);
         return res.status(400).json({
           success: false,
-          message: `Missing required answers for ${label} committee: ${missingNames}`,
+          message: buildMissingFieldsMessage(missingNames),
+          missingFields: missingNames,
         });
       }
     }
 
-    application.submissionStatus = 'submitted';
-    application.submittedAt = Date.now();
-    await application.save();
+    const submittedAt = new Date();
+    const updatedApp = await InternshipApplication.findOneAndUpdate(
+      {
+        _id: req.params.id,
+        userId: req.user.uuid,
+        submissionStatus: 'draft',
+        deletedAt: null,
+      },
+      {
+        submissionStatus: 'submitted',
+        submittedAt,
+        lastModifiedAt: submittedAt,
+      },
+      { new: true, runValidators: true },
+    );
+
+    if (!updatedApp) {
+      return res.status(400).json({
+        success: false,
+        message: 'Application has already been submitted',
+      });
+    }
 
     return res.status(200).json({
       success: true,
-      data: application,
+      data: updatedApp,
+      message: 'Application submitted successfully',
     });
   } catch (error) {
     return res.status(500).json({
@@ -531,6 +676,7 @@ module.exports = {
   getAllApplications,
   getApplicationById,
   updateApplication,
+  updateApplicationStatus,
   deleteApplication,
   getOwnApplication,
   submitApplication,

--- a/app/api/v1/internship/index.js
+++ b/app/api/v1/internship/index.js
@@ -10,6 +10,7 @@ const {
   getAllApplications,
   getApplicationById,
   updateApplication,
+  updateApplicationStatus,
   deleteApplication,
   getOwnApplication,
   submitApplication,
@@ -26,6 +27,7 @@ const {
 const {
   validateCreateApplication,
   validateUpdateApplication,
+  validateUpdateApplicationStatus,
   validateGetApplications,
   validateMongoId,
 } = require('./middleware/validation');
@@ -48,6 +50,9 @@ router.post('/applications', auth, strictCreateApplicationLimiter, validateCreat
 
 // PUT (update) an application by ID
 router.put('/applications/:id', auth, validateUpdateApplication, updateApplication);
+
+// PUT update review status for one committee choice (officers/admins only)
+router.put('/applications/:id/status', auth, adminOrOfficer, validateUpdateApplicationStatus, updateApplicationStatus);
 
 // POST submit a draft application (member+)
 router.post('/applications/:id/submit', auth, strictCreateApplicationLimiter, validateMongoId, submitApplication);

--- a/app/api/v1/internship/middleware/validation.js
+++ b/app/api/v1/internship/middleware/validation.js
@@ -11,6 +11,12 @@ const STATUS_OPTIONS = [
   'rejected',
 ];
 
+const STATUS_FIELD_OPTIONS = [
+  'firstChoiceStatus',
+  'secondChoiceStatus',
+  'thirdChoiceStatus',
+];
+
 const EMAIL_REGEX = /^\S+@(ucla\.edu|g\.ucla\.edu)$/;
 
 async function validateCommitteeById(value, fieldLabel) {
@@ -257,6 +263,24 @@ const validateUpdateApplication = [
   handleValidationErrors,
 ];
 
+// Validate application review status update
+const validateUpdateApplicationStatus = [
+  param('id').isMongoId().withMessage('Invalid application ID'),
+  body('statusField')
+    .exists()
+    .withMessage('statusField is required')
+    .bail()
+    .isIn(STATUS_FIELD_OPTIONS)
+    .withMessage('statusField must be one of firstChoiceStatus, secondChoiceStatus, thirdChoiceStatus'),
+  body('status')
+    .exists()
+    .withMessage('status is required')
+    .bail()
+    .isIn(STATUS_OPTIONS)
+    .withMessage('Invalid application status'),
+  handleValidationErrors,
+];
+
 // Validate get all applications query
 const validateGetApplications = [
   query('firstChoiceStatus')
@@ -297,6 +321,7 @@ module.exports = {
   handleValidationErrors,
   validateCreateApplication,
   validateUpdateApplication,
+  validateUpdateApplicationStatus,
   validateGetApplications,
   validateMongoId,
 };

--- a/app/api/v1/internship/middleware/validation.js
+++ b/app/api/v1/internship/middleware/validation.js
@@ -248,18 +248,9 @@ const validateUpdateApplication = [
     .withMessage('Question text is required'),
   body('thirdChoiceResponses.*.answer').optional().trim().notEmpty()
     .withMessage('Answer is required'),
-  body('firstChoiceStatus')
-    .optional()
-    .isIn(STATUS_OPTIONS)
-    .withMessage('Invalid first choice status'),
-  body('secondChoiceStatus')
-    .optional()
-    .isIn(STATUS_OPTIONS)
-    .withMessage('Invalid second choice status'),
-  body('thirdChoiceStatus')
-    .optional()
-    .isIn(STATUS_OPTIONS)
-    .withMessage('Invalid third choice status'),
+  body('firstChoiceStatus').not().exists().withMessage('firstChoiceStatus is managed by reviewers'),
+  body('secondChoiceStatus').not().exists().withMessage('secondChoiceStatus is managed by reviewers'),
+  body('thirdChoiceStatus').not().exists().withMessage('thirdChoiceStatus is managed by reviewers'),
   handleValidationErrors,
 ];
 

--- a/app/api/v1/internship/utils/deadlineValidation.js
+++ b/app/api/v1/internship/utils/deadlineValidation.js
@@ -1,0 +1,21 @@
+function getCommitteeLabel(committee) {
+  return committee.displayName || committee.name || committee.id;
+}
+
+function findCommitteesPastDeadline(committees, referenceDate = new Date()) {
+  return committees.filter((committee) => (
+    committee.applicationDeadline
+    && new Date(committee.applicationDeadline) <= referenceDate
+  ));
+}
+
+function buildDeadlineViolationMessage(committees) {
+  const labels = committees.map(getCommitteeLabel).join(', ');
+  return `Application deadline has passed for: ${labels}`;
+}
+
+module.exports = {
+  findCommitteesPastDeadline,
+  buildDeadlineViolationMessage,
+  getCommitteeLabel,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2816,9 +2816,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2833,9 +2830,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2850,9 +2844,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2867,9 +2858,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2884,9 +2872,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2901,9 +2886,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2918,9 +2900,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2935,9 +2914,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9196,6 +9172,38 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {

--- a/tests/internship-application-status.test.js
+++ b/tests/internship-application-status.test.js
@@ -1,0 +1,217 @@
+jest.mock('../app/api/v1/internship/models/InternshipApplication', () => ({
+  InternshipApplication: {
+    findById: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+  },
+  getCurrentApplicationCycle: jest.fn(() => '2026-2027'),
+}));
+
+jest.mock('../app/api/v1/internship/models/Committee', () => ({
+  Committee: {
+    findById: jest.fn(),
+  },
+}));
+
+const {
+  InternshipApplication,
+} = require('../app/api/v1/internship/models/InternshipApplication');
+const { Committee } = require('../app/api/v1/internship/models/Committee');
+const {
+  updateApplicationStatus,
+} = require('../app/api/v1/internship/controllers/applicationController');
+
+function mockResponse() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function mockUser({
+  accessType = 'OFFICER',
+  committees = ['dev'],
+} = {}) {
+  return {
+    isAdmin: jest.fn(() => accessType === 'ADMIN'),
+    isOfficer: jest.fn(() => accessType === 'OFFICER'),
+    getDataValue: jest.fn((field) => {
+      if (field === 'committees') {
+        return committees;
+      }
+      return undefined;
+    }),
+  };
+}
+
+function mockApplication(overrides = {}) {
+  return {
+    _id: 'application-1',
+    firstChoiceCommittee: 'committee-1',
+    secondChoiceCommittee: 'committee-2',
+    thirdChoiceCommittee: null,
+    firstChoiceStatus: 'pending',
+    secondChoiceStatus: 'pending',
+    thirdChoiceStatus: 'pending',
+    submissionStatus: 'submitted',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function mockCommittee(overrides = {}) {
+  return {
+    _id: 'committee-1',
+    id: 'committee-1',
+    name: 'dev',
+    displayName: 'ACM Dev',
+    ...overrides,
+  };
+}
+
+function mockCommitteeFindById(committee) {
+  Committee.findById.mockReturnValue({
+    select: jest.fn().mockResolvedValue(committee),
+  });
+}
+
+describe('updateApplicationStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('updates only the requested status field for an officer assigned to the selected committee', async () => {
+    const updatedApplication = mockApplication({ firstChoiceStatus: 'accepted' });
+    InternshipApplication.findById.mockResolvedValue(mockApplication());
+    InternshipApplication.findByIdAndUpdate.mockResolvedValue(updatedApplication);
+    mockCommitteeFindById(mockCommittee());
+
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser({ committees: ['Dev'] }),
+      body: {
+        statusField: 'firstChoiceStatus',
+        status: 'accepted',
+        firstName: 'Malicious Change',
+      },
+    };
+    const res = mockResponse();
+
+    await updateApplicationStatus(req, res);
+
+    expect(InternshipApplication.findByIdAndUpdate).toHaveBeenCalledWith(
+      'application-1',
+      {
+        firstChoiceStatus: 'accepted',
+        lastModifiedAt: expect.any(Date),
+      },
+      { new: true, runValidators: true },
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      data: updatedApplication,
+    }));
+  });
+
+  test('prevents officers from updating a status for a committee they do not manage', async () => {
+    InternshipApplication.findById.mockResolvedValue(mockApplication());
+    mockCommitteeFindById(mockCommittee({ name: 'design', displayName: 'Design' }));
+
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser({ committees: ['Dev'] }),
+      body: {
+        statusField: 'firstChoiceStatus',
+        status: 'rejected',
+      },
+    };
+    const res = mockResponse();
+
+    await updateApplicationStatus(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: false,
+      message: 'You do not have permission to update first choice status',
+    }));
+    expect(InternshipApplication.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('prevents non-officer members from updating application status', async () => {
+    InternshipApplication.findById.mockResolvedValue(mockApplication());
+    mockCommitteeFindById(mockCommittee());
+
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser({ accessType: 'STANDARD', committees: [] }),
+      body: {
+        statusField: 'firstChoiceStatus',
+        status: 'accepted',
+      },
+    };
+    const res = mockResponse();
+
+    await updateApplicationStatus(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: false,
+      message: 'You do not have permission to update first choice status',
+    }));
+    expect(InternshipApplication.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('allows admins to update any committee choice status', async () => {
+    const updatedApplication = mockApplication({ secondChoiceStatus: 'reviewing' });
+    InternshipApplication.findById.mockResolvedValue(mockApplication());
+    InternshipApplication.findByIdAndUpdate.mockResolvedValue(updatedApplication);
+    mockCommitteeFindById(mockCommittee({ name: 'design', displayName: 'Design' }));
+
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser({ accessType: 'ADMIN', committees: [] }),
+      body: {
+        statusField: 'secondChoiceStatus',
+        status: 'reviewing',
+      },
+    };
+    const res = mockResponse();
+
+    await updateApplicationStatus(req, res);
+
+    expect(InternshipApplication.findByIdAndUpdate).toHaveBeenCalledWith(
+      'application-1',
+      {
+        secondChoiceStatus: 'reviewing',
+        lastModifiedAt: expect.any(Date),
+      },
+      { new: true, runValidators: true },
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('rejects status updates for draft applications', async () => {
+    InternshipApplication.findById.mockResolvedValue(mockApplication({
+      submissionStatus: 'draft',
+    }));
+
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser(),
+      body: {
+        statusField: 'firstChoiceStatus',
+        status: 'accepted',
+      },
+    };
+    const res = mockResponse();
+
+    await updateApplicationStatus(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: false,
+      message: 'Application status can only be updated after submission',
+    }));
+    expect(InternshipApplication.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/internship-submit-application.test.js
+++ b/tests/internship-submit-application.test.js
@@ -1,0 +1,243 @@
+jest.mock('../app/api/v1/internship/models/InternshipApplication', () => ({
+  InternshipApplication: {
+    findById: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+  },
+  getCurrentApplicationCycle: jest.fn(() => '2026-2027'),
+}));
+
+jest.mock('../app/api/v1/internship/models/Committee', () => ({
+  Committee: {
+    find: jest.fn(),
+  },
+}));
+
+const {
+  InternshipApplication,
+} = require('../app/api/v1/internship/models/InternshipApplication');
+const { Committee } = require('../app/api/v1/internship/models/Committee');
+const {
+  submitApplication,
+  updateApplication,
+} = require('../app/api/v1/internship/controllers/applicationController');
+
+function mockResponse() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function mockUser(uuid = 'owner-user') {
+  return {
+    uuid,
+    isAdmin: jest.fn(() => false),
+    isOfficer: jest.fn(() => false),
+  };
+}
+
+function mockCommittee(overrides = {}) {
+  return {
+    _id: 'committee-1',
+    id: 'committee-1',
+    name: 'dev',
+    displayName: 'ACM Dev',
+    isActive: true,
+    applicationDeadline: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    customQuestions: [
+      {
+        questionKey: 'why-dev',
+        questionText: 'Why Dev?',
+        required: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function mockApplication(overrides = {}) {
+  return {
+    _id: 'application-1',
+    userId: 'owner-user',
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    email: 'ada@g.ucla.edu',
+    university: 'UCLA',
+    major: 'Computer Science',
+    graduationYear: 2027,
+    firstChoiceCommittee: 'committee-1',
+    firstChoiceResponses: [
+      {
+        questionKey: 'why-dev',
+        question: 'Why Dev?',
+        answer: 'I like building useful tools.',
+      },
+    ],
+    secondChoiceCommittee: null,
+    thirdChoiceCommittee: null,
+    submissionStatus: 'draft',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function mockCommitteeFind(committees) {
+  Committee.find.mockReturnValue({
+    select: jest.fn().mockResolvedValue(committees),
+  });
+}
+
+describe('submitApplication', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rejects submission from a non-owner', async () => {
+    InternshipApplication.findById.mockResolvedValue(mockApplication());
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser('other-user'),
+    };
+    const res = mockResponse();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: false,
+      message: 'You do not have permission to submit this application',
+    }));
+    expect(InternshipApplication.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rejects submission when a selected committee deadline has passed', async () => {
+    InternshipApplication.findById.mockResolvedValue(mockApplication());
+    mockCommitteeFind([
+      mockCommittee({
+        applicationDeadline: new Date(Date.now() - 60 * 1000),
+      }),
+    ]);
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser(),
+    };
+    const res = mockResponse();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: false,
+      message: 'Application deadline has passed for: ACM Dev',
+    }));
+    expect(InternshipApplication.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rejects submission when required committee answers are missing', async () => {
+    InternshipApplication.findById.mockResolvedValue(mockApplication({
+      firstChoiceResponses: [],
+    }));
+    mockCommitteeFind([mockCommittee()]);
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser(),
+    };
+    const res = mockResponse();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: false,
+      message: 'Missing required fields: ACM Dev: Why Dev?',
+      missingFields: ['ACM Dev: Why Dev?'],
+    }));
+    expect(InternshipApplication.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('prevents double submission', async () => {
+    InternshipApplication.findById.mockResolvedValue(mockApplication({
+      submissionStatus: 'submitted',
+    }));
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser(),
+    };
+    const res = mockResponse();
+
+    await submitApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: false,
+      message: 'Application has already been submitted',
+    }));
+    expect(InternshipApplication.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('returns the updated submitted application with submittedAt', async () => {
+    const updatedApplication = mockApplication({
+      submissionStatus: 'submitted',
+      submittedAt: new Date(),
+    });
+    InternshipApplication.findById.mockResolvedValue(mockApplication());
+    InternshipApplication.findOneAndUpdate.mockResolvedValue(updatedApplication);
+    mockCommitteeFind([mockCommittee()]);
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser(),
+    };
+    const res = mockResponse();
+
+    await submitApplication(req, res);
+
+    expect(InternshipApplication.findOneAndUpdate).toHaveBeenCalledWith(
+      {
+        _id: 'application-1',
+        userId: 'owner-user',
+        submissionStatus: 'draft',
+        deletedAt: null,
+      },
+      expect.objectContaining({
+        submissionStatus: 'submitted',
+        submittedAt: expect.any(Date),
+        lastModifiedAt: expect.any(Date),
+      }),
+      { new: true, runValidators: true },
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      data: updatedApplication,
+      message: 'Application submitted successfully',
+    }));
+  });
+});
+
+describe('updateApplication submitted locking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('prevents the owner from editing a submitted application', async () => {
+    InternshipApplication.findById.mockResolvedValue(mockApplication({
+      submissionStatus: 'submitted',
+    }));
+    const req = {
+      params: { id: 'application-1' },
+      user: mockUser(),
+      body: { major: 'Math' },
+    };
+    const res = mockResponse();
+
+    await updateApplication(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: false,
+      message: 'You cannot update a submitted application',
+    }));
+    expect(InternshipApplication.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Resolves #140 
[ ] Implemented updateApplicationStatus in the application controller.

[ ] Defined the PUT /:id/status route in the application router.

[ ] Applied the adminOrOfficer middleware to the route.

[ ] Added validation logic to ensure the status string matches the allowed enum values.

[ ] Tested the endpoint to ensure officers cannot update statuses for committees they do not manage.