### PR TITLE
Committee Bulk Status Endpoint

### DIFF
--- a/app/api/v1/internship/controllers/committeeController.js
+++ b/app/api/v1/internship/controllers/committeeController.js
@@ -116,6 +116,7 @@ async function bulkUpdateCommitteeStatus(req, res, next) {
       : {};
 
     const result = await Committee.updateMany(filter, { $set: { isActive } });
+    // result.modifiedCount and result.nModified options are to support Mongoose 6+ and older versions of Mongoose
     const modified = (result && (result.modifiedCount !== undefined ? result.modifiedCount : result.nModified)) || 0;
 
     return res.json({ success: true, modified });

--- a/app/api/v1/internship/controllers/committeeController.js
+++ b/app/api/v1/internship/controllers/committeeController.js
@@ -98,6 +98,32 @@ async function deleteCommittee(req, res, next) {
   }
 }
 
+async function bulkUpdateCommitteeStatus(req, res, next) {
+  try {
+    const { action, committeeIds } = req.body;
+
+    if (action !== 'open' && action !== 'close') {
+      throw new error.BadRequest("action must be either 'open' or 'close'.");
+    }
+
+    if (committeeIds !== undefined && !Array.isArray(committeeIds)) {
+      throw new error.BadRequest('committeeIds must be an array of strings.');
+    }
+
+    const isActive = action === 'open';
+    const filter = (Array.isArray(committeeIds) && committeeIds.length > 0)
+      ? { _id: { $in: committeeIds } }
+      : {};
+
+    const result = await Committee.updateMany(filter, { $set: { isActive } });
+    const modified = (result && (result.modifiedCount !== undefined ? result.modifiedCount : result.nModified)) || 0;
+
+    return res.json({ success: true, modified });
+  } catch (e) {
+    return next(e);
+  }
+}
+
 async function getAllCommitteesAdmin(req, res, next) {
   try {
     const committees = await Committee
@@ -118,4 +144,5 @@ module.exports = {
   updateCommitteeQuestions,
   updateCommitteeAdmin,
   deleteCommittee,
+  bulkUpdateCommitteeStatus,
 };

--- a/app/api/v1/internship/index.js
+++ b/app/api/v1/internship/index.js
@@ -23,6 +23,7 @@ const {
   updateCommitteeQuestions,
   updateCommitteeAdmin,
   deleteCommittee,
+  bulkUpdateCommitteeStatus,
 } = require('./controllers/committeeController');
 const {
   validateCreateApplication,
@@ -65,6 +66,9 @@ router.get('/committees', getAllCommittees);
 
 // GET all committees including inactive (admin only) - must be before /:id
 router.get('/committees/admin', auth, admin, getAllCommitteesAdmin);
+
+// PATCH bulk open/close committees (admin only) - must be before /:id routes
+router.patch('/committees/bulk-status', auth, admin, committeeRateLimiter, bulkUpdateCommitteeStatus);
 
 // GET a single committee by ID
 router.get('/committees/:id', auth, getCommitteeById);


### PR DESCRIPTION
## Description

Created endpoint for PATCH /api/v1/internship/committees/bulk-status, a bulk update mechanism allowing administrators to switch the isActive state of multiple committees in one request.

## Related Issue

Resolves #135 

## Steps to view & test changes:

I used the help of AI to help me write the curl commands to test the endpoints. All modified counts are accurate and so are the statuses of the committees whose actions were modified.

Make sure jq is installed with `sudo apt install jq`

1. In mongosh, go to `membership-portal-internship` and add a test case
```
db.committees.insertMany([
  { name: "hack", displayName: "Hack", isActive: true,  subcommittees: [], customQuestions: [] },
  { name: "ai",   displayName: "AI",   isActive: true,  subcommittees: [], customQuestions: [] },
  { name: "w",    displayName: "W",    isActive: false, subcommittees: [], customQuestions: [] }
])
```

Confirm with `db.committees.find({}, { _id:1, name:1, isActive:1 }).toArray()` and note the committees' status.

2. Get an administrator account using dev@g.ucla.edu and retrieve its token
```
BASE=http://localhost:8080/app/api/v1
TOKEN=$(curl -sS -X POST $BASE/auth/dev-login -H 'Content-Type: application/json' -d '{}' | jq -r .token)
```

3. Run the following tests
    a. Test 1: Admin-only access control (403 for non-admin)

```
docker exec -it dev-postgres-1 psql -U postgres -c "UPDATE users SET \"accessType\" = 'STANDARD' WHERE email = 'dev@g.ucla.edu';"
STD_TOKEN=$(curl -sS -X POST $BASE/auth/dev-login -H 'Content-Type: application/json' -d '{}' | jq -r .token)
 
curl -sS -o /dev/null -w "Non-admin → HTTP %{http_code}\n" \
  -X PATCH $BASE/internship/committees/bulk-status \
  -H "Content-Type: application/json" -H "Authorization: Bearer $STD_TOKEN" \
  -d '{"action":"open"}'
```

**Expect: Non-admin → HTTP 403**

Restore back to admin

```
docker exec -it dev-postgres-1 psql -U postgres -c "UPDATE users SET \"accessType\" = 'ADMIN' WHERE email = 'dev@g.ucla.edu';"
TOKEN=$(curl -sS -X POST $BASE/auth/dev-login -H 'Content-Type: application/json' -d '{}' | jq -r .token)
```

    b. Test 2: Targeting specific committees (committeeIds provided)

Replace $HACK_ID and $AI_ID with their IDs found in MongoDB.

```
curl -sS -X PATCH $BASE/internship/committees/bulk-status \
  -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" \
  -d "{\"action\":\"close\",\"committeeIds\":[\"$HACK_ID\",\"$AI_ID\"]}" | jq
```

**Expect: { "success": true, "modified": 2 }**

    c. Test 3: Empty array targets all

```
curl -sS -X PATCH $BASE/internship/committees/bulk-status \
  -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" \
  -d '{"action":"open","committeeIds":[]}' | jq
```

**Expect: { "success": true, "modified": 3 }**

    d. Test 4: Missing committeeIds field targets all

```
curl -sS -X PATCH $BASE/internship/committees/bulk-status \
  -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" \
  -d '{"action":"close"}' | jq
```

**Expect: { "success": true, "modified": 3 }**

   

## How Has This Been Tested?

- [ ] Unit tests
- [x] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)



Admin-only access control (403 for non-admin)
<img width="1495" height="93" alt="image" src="https://github.com/user-attachments/assets/8338d045-a266-4bb4-87db-b04cbbc2ec90" />



Targeting specific committees (committeeIds provided)
<img width="1486" height="327" alt="image" src="https://github.com/user-attachments/assets/a768fa8d-2f8b-4ce2-82f1-30d7fd3b7f7e" />


Empty array targets all
<img width="1488" height="267" alt="image" src="https://github.com/user-attachments/assets/edf4da18-7eb8-4f32-a5d6-4db4cedfcc49" />


Missing committeeIds field targets all
<img width="1497" height="281" alt="image" src="https://github.com/user-attachments/assets/9e4346d3-94f0-41b4-b1f9-dd412b3e8500" />






