### PR TITLE
Create Application Count and tests

### DIFF
--- a/app/api/v1/internship/controllers/committeeController.js
+++ b/app/api/v1/internship/controllers/committeeController.js
@@ -1,6 +1,34 @@
 const { Committee } = require('../models/Committee');
+const { InternshipApplication } = require('../models/InternshipApplication');
 const { canManageCommitteeResource } = require('../../auth/committeeScope');
 const error = require('../../../../error');
+
+// Count submitted (non-deleted) applications per committee across all 3 choice slots.
+// $setUnion dedupes per application so a committee selected in multiple slots only counts once.
+async function getApplicationCountsByCommittee() {
+  const counts = await InternshipApplication.aggregate([
+    { $match: { deletedAt: null, submissionStatus: 'submitted' } },
+    {
+      $project: {
+        committees: {
+          $setUnion: [
+            { $cond: [{ $ifNull: ['$firstChoiceCommittee', false] }, ['$firstChoiceCommittee'], []] },
+            { $cond: [{ $ifNull: ['$secondChoiceCommittee', false] }, ['$secondChoiceCommittee'], []] },
+            { $cond: [{ $ifNull: ['$thirdChoiceCommittee', false] }, ['$thirdChoiceCommittee'], []] },
+          ],
+        },
+      },
+    },
+    { $unwind: '$committees' },
+    { $group: { _id: '$committees', count: { $sum: 1 } } },
+  ]);
+
+  const countByCommitteeId = new Map();
+  counts.forEach((row) => {
+    countByCommitteeId.set(row._id.toString(), row.count);
+  });
+  return countByCommitteeId;
+}
 
 async function getAllCommittees(req, res, next) {
   try {
@@ -127,11 +155,17 @@ async function bulkUpdateCommitteeStatus(req, res, next) {
 
 async function getAllCommitteesAdmin(req, res, next) {
   try {
-    const committees = await Committee
-      .find({})
-      .sort({ displayName: 1 });
+    const [committees, countByCommitteeId] = await Promise.all([
+      Committee.find({}).sort({ displayName: 1 }),
+      getApplicationCountsByCommittee(),
+    ]);
 
-    return res.json({ error: null, committees });
+    const committeesWithCounts = committees.map((committee) => ({
+      ...committee.toObject(),
+      applicationCount: countByCommitteeId.get(committee._id.toString()) || 0,
+    }));
+
+    return res.json({ error: null, committees: committeesWithCounts });
   } catch (error) {
     return next(error);
   }

--- a/tests/committee-endpoints.test.js
+++ b/tests/committee-endpoints.test.js
@@ -16,13 +16,23 @@ jest.mock('../app/api/v1/internship/models/Committee', () => ({
   Committee: {
     findById: jest.fn(),
     findByIdAndUpdate: jest.fn(),
+    find: jest.fn(),
   },
 }));
 
+jest.mock('../app/api/v1/internship/models/InternshipApplication', () => ({
+  InternshipApplication: {
+    aggregate: jest.fn(),
+  },
+  getCurrentApplicationCycle: jest.fn(),
+}));
+
 const { Committee } = require('../app/api/v1/internship/models/Committee');
+const { InternshipApplication } = require('../app/api/v1/internship/models/InternshipApplication');
 const {
   updateCommitteeQuestions,
   updateCommitteeAdmin,
+  getAllCommitteesAdmin,
 } = require('../app/api/v1/internship/controllers/committeeController');
 const { isAdmin } = require('../app/api/v1/auth');
 const error = require('../app/error');
@@ -241,5 +251,98 @@ describe('isAdmin middleware — gates PUT /committees/:id/admin', () => {
     const passed = next.mock.calls[0][0];
     expect(passed).toBeInstanceOf(error.Forbidden);
     expect(passed.status).toBe(403);
+  });
+});
+
+describe('getAllCommitteesAdmin (applicationCount)', () => {
+  // Mongoose chains .find().sort(); helper builds a chainable mock that resolves to `committees`.
+  const mockFindSort = (committees) => {
+    Committee.find.mockReturnValue({ sort: jest.fn().mockResolvedValue(committees) });
+  };
+
+  // Each fixture committee.toObject() should return a plain copy without the toObject method
+  // so it matches what the controller spreads into the response.
+  const makeCommittee = (id, displayName, extra = {}) => ({
+    _id: id,
+    displayName,
+    name: displayName.toLowerCase(),
+    isActive: true,
+    ...extra,
+    toObject() {
+      const { toObject, ...rest } = this;
+      return rest;
+    },
+  });
+
+  test('attaches applicationCount from aggregation, defaulting missing committees to 0', async () => {
+    const committees = [
+      makeCommittee('c1', 'Hack'),
+      makeCommittee('c2', 'AI'),
+      makeCommittee('c3', 'Studio'),
+    ];
+    mockFindSort(committees);
+    InternshipApplication.aggregate.mockResolvedValue([
+      { _id: { toString: () => 'c1' }, count: 5 },
+      { _id: { toString: () => 'c2' }, count: 2 },
+      // c3 absent → should default to 0
+    ]);
+
+    const req = { user: adminUser };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await getAllCommitteesAdmin(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledTimes(1);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.error).toBeNull();
+    expect(payload.committees).toHaveLength(3);
+    const byId = Object.fromEntries(payload.committees.map((c) => [c._id, c]));
+    expect(byId.c1.applicationCount).toBe(5);
+    expect(byId.c2.applicationCount).toBe(2);
+    expect(byId.c3.applicationCount).toBe(0);
+  });
+
+  test('aggregation pipeline filters to submitted, non-deleted apps and dedupes choice slots', async () => {
+    mockFindSort([]);
+    InternshipApplication.aggregate.mockResolvedValue([]);
+
+    await getAllCommitteesAdmin({ user: adminUser }, mockRes(), jest.fn());
+
+    expect(InternshipApplication.aggregate).toHaveBeenCalledTimes(1);
+    const pipeline = InternshipApplication.aggregate.mock.calls[0][0];
+    expect(pipeline[0]).toEqual({
+      $match: { deletedAt: null, submissionStatus: 'submitted' },
+    });
+    // $setUnion across the three choice fields ensures one application doesn't double-count
+    // a committee selected in multiple slots.
+    const projectStage = pipeline.find((s) => s.$project);
+    expect(projectStage.$project.committees.$setUnion).toBeDefined();
+    expect(pipeline.some((s) => s.$unwind === '$committees')).toBe(true);
+    expect(pipeline.some((s) => s.$group && s.$group._id === '$committees')).toBe(true);
+  });
+
+  test('returns 0 counts for every committee when there are no applications', async () => {
+    const committees = [makeCommittee('c1', 'Hack'), makeCommittee('c2', 'AI')];
+    mockFindSort(committees);
+    InternshipApplication.aggregate.mockResolvedValue([]);
+
+    const res = mockRes();
+    await getAllCommitteesAdmin({ user: adminUser }, res, jest.fn());
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.committees.map((c) => c.applicationCount)).toEqual([0, 0]);
+  });
+
+  test('forwards aggregation errors to next() instead of throwing', async () => {
+    mockFindSort([]);
+    const boom = new Error('mongo down');
+    InternshipApplication.aggregate.mockRejectedValue(boom);
+
+    const next = jest.fn();
+    await getAllCommitteesAdmin({ user: adminUser }, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(boom);
   });
 });


### PR DESCRIPTION
## Description

- Extends `GET /api/v1/internship/committees/admin` to include `applicationCount` per committee — no new route, no schema change, single round-trip for the admin Committees tab

- Aggregates across all 3 choice slots using `$setUnion`, so one application picking the same committee in multiple slots is counted once for that committee (an application picking 3 distinct committees contributes 1 to each)                                                                                                                  

## Related Issue

Resolves #318 (needed for frontend change)

## Steps to view & test changes                                                                                                                                                                                                                                                         
- Run the unit tests:
`npm test -- tests/committee-endpoints.test.js`
  
## How Has This Been Tested?

- [x] Manual tests
- [ ]  Responsive View

## Screenshots (if appropriate)

N/A