### PR TITLE
Fix: Optional Event Fields Part 2

### DIFF
--- a/app/db/schema/event.js
+++ b/app/db/schema/event.js
@@ -271,19 +271,19 @@ module.exports = (Sequelize, db) => {
       'attendanceCode',
       'attendancePoints',
     ]);
-    if (sanitizedEvent.cover !== undefined && sanitizedEvent.cover.length === 0) {
+    if (sanitizedEvent.cover != null && sanitizedEvent.cover.length === 0) {
       sanitizedEvent.cover = null;
     }
-    if (sanitizedEvent.eventLink !== undefined && sanitizedEvent.eventLink.length === 0) {
+    if (sanitizedEvent.eventLink != null && sanitizedEvent.eventLink.length === 0) {
       sanitizedEvent.eventLink = null;
     }
-    if (sanitizedEvent.description !== undefined && sanitizedEvent.description.length === 0) {
+    if (sanitizedEvent.description != null && sanitizedEvent.description.length === 0) {
       sanitizedEvent.description = null;
     }
-    if (sanitizedEvent.committee !== undefined && sanitizedEvent.committee.length === 0) {
+    if (sanitizedEvent.committee != null && sanitizedEvent.committee.length === 0) {
       delete sanitizedEvent.committee;
     }
-    if (sanitizedEvent.attendanceCode !== undefined && sanitizedEvent.attendanceCode.length === 0) {
+    if (sanitizedEvent.attendanceCode != null && sanitizedEvent.attendanceCode.length === 0) {
       delete sanitizedEvent.attendanceCode;
     }
 


### PR DESCRIPTION
Issue: [#327](https://github.com/uclaacm/membership-portal-ui/issues/327)

Addition to issue [#288](https://github.com/uclaacm/membership-portal-ui/issues/288) and pr https://github.com/uclaacm/membership-portal/pull/130

Updating an event with blank optional fields throws the error "Cannot read properties of null (reading 'length')".

This happens because in `membership-portal/app/db/schema/event.js`, the check `sanitizedEvent.<property> !== undefined` uses strict comparison, which doesn't account for `null` values. When an event is stored in the database, empty optional fields are saved as `null`, not `undefined`. The subsequent `.length` check then fails because `null` has no `.length` property.

To fix this, change the property to `sanitizedEvent.<property> != null`, which catches both `null` and `undefined`. The bug can also be fixed with `!= undefined` (equivalent to `!= null`), or explicitly with `!== null && !== undefined`.