### PR TITLE
Feat: add committee leaderboard endpoint ranked by event attendance

### DIFF
--- a/app/api/v1/membership/leaderboard/index.js
+++ b/app/api/v1/membership/leaderboard/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const error = require('../../../../error');
-const { User } = require('../../../../db');
+const { User, Attendance } = require('../../../../db');
 
 const router = express.Router();
 
@@ -18,10 +18,31 @@ router.route('/').get((req, res, next) => {
 
   return User.getLeaderboard(offset, limit)
     .then((users) => {
-      // map the user objects to base profile (name, picture, points)
       res.json({
         error: null,
         leaderboard: users.map((u) => u.getBaseProfile()),
+      });
+      return null;
+    })
+    .catch(next);
+});
+
+router.route('/:committee').get((req, res, next) => {
+  if (req.user.isPending()) return next(new error.Forbidden());
+
+  const offset = parseInt(req.query.offset, 10);
+  const limit = parseInt(req.query.limit, 10);
+
+  return Attendance.getCommitteeLeaderboard(req.params.committee, offset, limit)
+    .then((results) => {
+      res.json({
+        error: null,
+        leaderboard: results
+          .filter((r) => r.user !== null)
+          .map((r) => ({
+            ...r.user.getBaseProfile(),
+            eventsAttended: r.eventsAttended,
+          })),
       });
       return null;
     })

--- a/app/db/schema/attendance.js
+++ b/app/db/schema/attendance.js
@@ -118,6 +118,37 @@ module.exports = (Sequelize, db) => {
     return this.create({ user, event });
   };
 
+  Attendance.getCommitteeLeaderboard = function (committee, offset, limit) {
+    const safeOffset = (!offset || offset < 0) ? 0 : offset;
+    const safeLimit = (!limit || limit < 0) ? undefined : limit;
+    const Event = db.models.event;
+    const User = db.models.user;
+
+    return Event.getCommitteeEvents(committee)
+      .then((events) => {
+        const eventUuids = events.map((e) => e.getDataValue('uuid'));
+        return Promise.all(eventUuids.map((uuid) => Attendance.getAttendanceForEvent(uuid)));
+      })
+      .then((attendanceLists) => {
+        const countsByUser = {};
+        attendanceLists.forEach((attendances) => {
+          attendances.forEach((a) => {
+            const userUuid = a.getDataValue('user');
+            countsByUser[userUuid] = (countsByUser[userUuid] || 0) + 1;
+          });
+        });
+
+        const sorted = Object.entries(countsByUser)
+          .sort((a, b) => b[1] - a[1])
+          .slice(safeOffset, safeLimit !== undefined ? safeOffset + safeLimit : undefined);
+
+        return Promise.all(
+          sorted.map(([uuid, count]) => User.findByUUID(uuid)
+            .then((u) => ({ user: u, eventsAttended: count }))),
+        );
+      });
+  };
+
   Attendance.prototype.getPublic = function () {
     return {
       uuid: this.getDataValue('uuid'),


### PR DESCRIPTION
Issue: #11

Adds `GET /leaderboard/:committee`, returns users ranked by number of events attended for a given committee, rather than by points.

## Changes

- `app/db/schema/attendance.js`
  - Added `Attendance.getCommitteeLeaderboard(committee, offset, limit)` that:
    - Fetches committee events
    - Counts attendance per user
    - Returns users sorted by attendance count
  - Lives in the attendance schema because this is an attendance aggregation

- `app/api/v1/membership/leaderboard/index.js`
  - Added `/:committee` route that:
    - Calls the new DB function
    - Returns base profiles with an `eventsAttended` count