### PR TITLE
 fix: allow null for clearing secondChoiceCommittee/thirdChoiceCommittee on update

### DIFF
--- a/app/api/v1/internship/middleware/validation.js
+++ b/app/api/v1/internship/middleware/validation.js
@@ -213,13 +213,13 @@ const validateUpdateApplication = [
     .bail()
     .custom((value) => validateCommitteeById(value, 'first choice')),
   body('secondChoiceCommittee')
-    .optional()
+    .optional({ values: 'null' })
     .isMongoId()
     .withMessage('Second choice committee must be a valid MongoDB ID')
     .bail()
     .custom((value) => validateCommitteeById(value, 'second choice')),
   body('thirdChoiceCommittee')
-    .optional()
+    .optional({ values: 'null' })
     .isMongoId()
     .withMessage('Third choice committee must be a valid MongoDB ID')
     .bail()


### PR DESCRIPTION
## Description

Two-line change to `validateUpdateApplication`. The `secondChoiceCommittee` and `thirdChoiceCommittee` validators now accept `null` as a valid "clear this field" sentinel by switching from `.optional()` to `.optional({ values: 'null' })`.



## Related Issue

Related to membership-portal-ui PR: https://github.com/uclaacm/membership-portal-ui/pull/340

## Steps to view & test changes:

- With the wizard PR's branch on the UI side, sign in and visit `/internship/apply`.
- Pick three committees and refresh: draft re-hydrates with all three.
- Click the 3rd-ranked committee to unpick it, then refresh. Third choice is now gone (previously, it would silently come back).
- Repeat with the 1st and 2nd choice.

## How Has This Been Tested?

- [x] Manual tests