### PR TITLE
Changed validation to accept null for second and third choice committees

### DIFF
--- a/app/api/v1/internship/middleware/validation.js
+++ b/app/api/v1/internship/middleware/validation.js
@@ -128,13 +128,13 @@ const validateCreateApplication = [
     .bail()
     .custom((value) => validateCommitteeById(value, 'first choice')),
   body('secondChoiceCommittee')
-    .optional()
+    .optional({ nullable: true })
     .isMongoId()
     .withMessage('Second choice committee must be a valid MongoDB ID')
     .bail()
     .custom((value) => validateCommitteeById(value, 'second choice')),
   body('thirdChoiceCommittee')
-    .optional()
+    .optional({ nullable: true })
     .isMongoId()
     .withMessage('Third choice committee must be a valid MongoDB ID')
     .bail()
@@ -207,19 +207,19 @@ const validateUpdateApplication = [
     .isInt({ min: MIN_GRADUATION_YEAR })
     .withMessage(`Graduation year must be ${MIN_GRADUATION_YEAR} or later`),
   body('firstChoiceCommittee')
-    .optional()
+    .optional({ nullable: true })
     .isMongoId()
     .withMessage('First choice committee must be a valid MongoDB ID')
     .bail()
     .custom((value) => validateCommitteeById(value, 'first choice')),
   body('secondChoiceCommittee')
-    .optional()
+    .optional({ nullable: true })
     .isMongoId()
     .withMessage('Second choice committee must be a valid MongoDB ID')
     .bail()
     .custom((value) => validateCommitteeById(value, 'second choice')),
   body('thirdChoiceCommittee')
-    .optional()
+    .optional({ nullable: true })
     .isMongoId()
     .withMessage('Third choice committee must be a valid MongoDB ID')
     .bail()


### PR DESCRIPTION
Observation: Validation errors appeared in the frontend when selecting 1-2 committees, but not for 3 committees in step 1 of wizard. 

Problem: In validation.js, 2nd and 3rd committees are allowed to be .optional() which mean the fields could be empty. However, the "null" received in the payload from the frontend means the field is no longer empty --> trying to call .mongoId() fails,--> error! 

Solution: Update validation to accept null as a choice