### PR TITLE
Fix: Small adjustment in committeeController for membership-portal-ui

### DIFF
--- a/app/api/v1/internship/controllers/committeeController.js
+++ b/app/api/v1/internship/controllers/committeeController.js
@@ -116,6 +116,7 @@ async function bulkUpdateCommitteeStatus(req, res, next) {
       : {};
 
     const result = await Committee.updateMany(filter, { $set: { isActive } });
+    // result.modifiedCount and result.nModified options are to support Mongoose 6+ and older versions of Mongoose
     const modified = (result && (result.modifiedCount !== undefined ? result.modifiedCount : result.nModified)) || 0;
 
     return res.json({ success: true, modified });

--- a/app/api/v1/internship/controllers/committeeController.js
+++ b/app/api/v1/internship/controllers/committeeController.js
@@ -98,6 +98,32 @@ async function deleteCommittee(req, res, next) {
   }
 }
 
+async function bulkUpdateCommitteeStatus(req, res, next) {
+  try {
+    const { action, committeeIds } = req.body;
+
+    if (action !== 'open' && action !== 'close') {
+      throw new error.BadRequest("action must be either 'open' or 'close'.");
+    }
+
+    if (committeeIds !== undefined && !Array.isArray(committeeIds)) {
+      throw new error.BadRequest('committeeIds must be an array of strings.');
+    }
+
+    const isActive = action === 'open';
+    const filter = (Array.isArray(committeeIds) && committeeIds.length > 0)
+      ? { _id: { $in: committeeIds } }
+      : {};
+
+    const result = await Committee.updateMany(filter, { $set: { isActive } });
+    const modified = (result && (result.modifiedCount !== undefined ? result.modifiedCount : result.nModified)) || 0;
+
+    return res.json({ success: true, modified });
+  } catch (e) {
+    return next(e);
+  }
+}
+
 async function getAllCommitteesAdmin(req, res, next) {
   try {
     const committees = await Committee
@@ -118,4 +144,5 @@ module.exports = {
   updateCommitteeQuestions,
   updateCommitteeAdmin,
   deleteCommittee,
+  bulkUpdateCommitteeStatus,
 };

--- a/app/api/v1/internship/controllers/committeeController.js
+++ b/app/api/v1/internship/controllers/committeeController.js
@@ -5,7 +5,7 @@ const error = require('../../../../error');
 async function getAllCommittees(req, res, next) {
   try {
     const includeInactive = req.query.includeInactive === 'true' && req.user && req.user.isAdmin();
-    const filter = includeInactive ? {} : { isActive: true };
+    const filter = {};
 
     const committees = await Committee.find(filter).select('-__v').sort({ displayName: 1 });
 

--- a/app/api/v1/internship/index.js
+++ b/app/api/v1/internship/index.js
@@ -23,6 +23,7 @@ const {
   updateCommitteeQuestions,
   updateCommitteeAdmin,
   deleteCommittee,
+  bulkUpdateCommitteeStatus,
 } = require('./controllers/committeeController');
 const {
   validateCreateApplication,
@@ -65,6 +66,9 @@ router.get('/committees', getAllCommittees);
 
 // GET all committees including inactive (admin only) - must be before /:id
 router.get('/committees/admin', auth, admin, getAllCommitteesAdmin);
+
+// PATCH bulk open/close committees (admin only) - must be before /:id routes
+router.patch('/committees/bulk-status', auth, admin, committeeRateLimiter, bulkUpdateCommitteeStatus);
 
 // GET a single committee by ID
 router.get('/committees/:id', auth, getCommitteeById);


### PR DESCRIPTION
## Description

committeeController now returns all committees regardless of activity status (active/inactive). This ensures that the frontend sees all committees and can display them accordingly. 


Relevant to: uclaacm/membership-portal-ui#343

<img width="477" height="448" alt="image" src="https://github.com/user-attachments/assets/44b99a09-094f-46d3-9d2b-6fe820937d8d" />
