### PR TITLE
Feat: Officer Emails Endpoint

### DIFF
--- a/app/api/v1/admin.js
+++ b/app/api/v1/admin.js
@@ -124,16 +124,19 @@ router.get('/officers/emails', authenticated, exportRateLimit, async (req, res, 
       return res.status(403).json({ error: 'Admin access required' });
     }
 
-    // get optional parameters in endpoint
+    // get optional query parameters in endpoint
     const { committee, format } = req.query;
-    const committees = committee ? [].concat(committee) : null;
+    const committees = committee ? [].concat(committee).map((c) => c.toLowerCase()) : null;
 
     const officers = await User.findAll({ where: { accessType: 'OFFICER' } });
 
     // filter officers by one or more committees
     let filtered;
     if (committees) {
-      filtered = officers.filter((u) => (u.getDataValue('committees') || []).some((c) => committees.includes(c)));
+      filtered = officers.filter((u) => {
+        const officerCommittees = u.getDataValue('committees') || [];
+        return officerCommittees.some((c) => committees.includes(c.toLowerCase()));
+      });
     } else {
       filtered = officers;
     }

--- a/app/api/v1/admin.js
+++ b/app/api/v1/admin.js
@@ -124,24 +124,26 @@ router.get('/officers/emails', authenticated, exportRateLimit, async (req, res, 
       return res.status(403).json({ error: 'Admin access required' });
     }
 
+    // get optional parameters in endpoint
     const { committee, format } = req.query;
+    const committees = committee ? [].concat(committee) : null;
 
     const officers = await User.findAll({ where: { accessType: 'OFFICER' } });
 
-    // filter officers by committee
+    // filter officers by one or more committees
     let filtered;
-    if (committee) {
-      filtered = officers.filter((u) => (u.getDataValue('committees') || []).includes(committee));
+    if (committees) {
+      filtered = officers.filter((u) => (u.getDataValue('committees') || []).some((c) => committees.includes(c)));
     } else {
       filtered = officers;
     }
-    
+
     const emails = filtered.map((u) => u.getDataValue('email'));
 
     // logs activity in Activity table in database
     Activity.createMilestone(
       req.user.getDataValue('uuid'),
-      `Admin exported officer emails${committee ? ` for committee: ${committee}` : ''} (${emails.length} results)`,
+      `Admin exported officer emails${committees ? ` for committees: ${committees.join(', ')}` : ''} (${emails.length} results)`,
     );
 
     // optional csv format

--- a/app/api/v1/admin.js
+++ b/app/api/v1/admin.js
@@ -108,4 +108,20 @@ router.delete('/promote-officer', authenticated, async (req, res, next) => {
   }
 });
 
+// GET /app/api/v1/admin/officers/emails
+router.get('/officers/emails', authenticated, async (req, res, next) => {
+  try {
+    if (!req.user || !req.user.isAdmin()) {
+      return res.status(403).json({ error: 'Admin access required' });
+    }
+
+    const officers = await User.findAll({ where: { accessType: 'OFFICER' } });
+    const emails = officers.map((u) => u.getDataValue('email'));
+
+    return res.json({ error: null, emails });
+  } catch (err) {
+    return next(err);
+  }
+});
+
 module.exports = { router };

--- a/app/api/v1/admin.js
+++ b/app/api/v1/admin.js
@@ -1,9 +1,18 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 
 const router = express.Router();
 const bcrypt = require('bcrypt');
-const { User } = require('../../db');
+const { User, Activity } = require('../../db');
 const { authenticated } = require('./auth');
+
+const exportRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 1,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Rate limit exceeded. Try again in 1 minute.' },
+});
 
 const hardcodedPassword = '$2b$10$t5itVIAG3WQTZsIKq2Fs9e8qbSAJAB7WgIXjTnE75HOEV13TzF6bK';
 
@@ -109,14 +118,38 @@ router.delete('/promote-officer', authenticated, async (req, res, next) => {
 });
 
 // GET /app/api/v1/admin/officers/emails
-router.get('/officers/emails', authenticated, async (req, res, next) => {
+router.get('/officers/emails', authenticated, exportRateLimit, async (req, res, next) => {
   try {
     if (!req.user || !req.user.isAdmin()) {
       return res.status(403).json({ error: 'Admin access required' });
     }
 
+    const { committee, format } = req.query;
+
     const officers = await User.findAll({ where: { accessType: 'OFFICER' } });
-    const emails = officers.map((u) => u.getDataValue('email'));
+
+    // filter officers by committee
+    let filtered;
+    if (committee) {
+      filtered = officers.filter((u) => (u.getDataValue('committees') || []).includes(committee));
+    } else {
+      filtered = officers;
+    }
+    
+    const emails = filtered.map((u) => u.getDataValue('email'));
+
+    // logs activity in Activity table in database
+    Activity.createMilestone(
+      req.user.getDataValue('uuid'),
+      `Admin exported officer emails${committee ? ` for committee: ${committee}` : ''} (${emails.length} results)`,
+    );
+
+    // optional csv format
+    if (format === 'csv') {
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader('Content-Disposition', 'attachment; filename="officer-emails.csv"');
+      return res.send(`email\n${emails.join('\n')}`);
+    }
 
     return res.json({ error: null, emails });
   } catch (err) {


### PR DESCRIPTION
Resolves: #111 

Adds API endpoint GET /app/api/v1/admin/officers/emails inside `membership-portal/app/api/v1/admin.js`. 

- user must be authenticated and an admin
- users can query for specific committee(s) at the end of the url, e.g. `?committee=Cyber`
- users can query for csv format instead of json by adding `?format=csv`
- request is rate limited to 1 req/min
- whenever a request is processed, a new entry is added to Activity table in database to document the action