### PR TITLE
Feat: Add admin/officer leaderboard endpoint with filters

### DIFF
--- a/app/api/v1/membership/leaderboard/admin-filters.js
+++ b/app/api/v1/membership/leaderboard/admin-filters.js
@@ -1,0 +1,45 @@
+const Sequelize = require('sequelize');
+
+// Maps frontend role labels to the accessType values stored in the DB.
+// The frontend uses "MEMBER" but the DB stores "STANDARD".
+const ROLE_MAP = {
+  MEMBER: 'STANDARD',
+  OFFICER: 'OFFICER',
+  ADMIN: 'ADMIN',
+};
+
+/**
+ * Builds a Sequelize `where` clause for the admin leaderboard based on the
+ * caller's role and any query-string filters (?year, ?role, ?committee).
+ *
+ * Permission model:
+ *   - Officers can only see STANDARD members and may filter by year.
+ *   - Admins can see all users and may filter by year, role, and committee.
+ *   - Role and committee filters sent by officers are silently ignored.
+ */
+function buildAdminLeaderboardQuery(query, caller) {
+  const where = {};
+  const isAdmin = caller.isAdmin();
+
+  // Officers are restricted to viewing STANDARD members only
+  if (!isAdmin) {
+    where.accessType = 'STANDARD';
+  }
+
+  const year = parseInt(query.year, 10);
+  if (!Number.isNaN(year) && year >= 1 && year <= 5) {
+    where.year = year;
+  }
+
+  if (isAdmin && query.role && ROLE_MAP[query.role]) {
+    where.accessType = ROLE_MAP[query.role];
+  }
+
+  if (isAdmin && query.committee) {
+    where.committees = { [Sequelize.Op.contains]: [query.committee] };
+  }
+
+  return where;
+}
+
+module.exports = { buildAdminLeaderboardQuery, ROLE_MAP };

--- a/app/api/v1/membership/leaderboard/index.js
+++ b/app/api/v1/membership/leaderboard/index.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const error = require('../../../../error');
 const { User, Attendance } = require('../../../../db');
+const { isOfficerOrAdmin } = require('../../auth');
+const { buildAdminLeaderboardQuery } = require('./admin-filters');
 
 const router = express.Router();
 
@@ -23,6 +25,29 @@ router.route('/').get((req, res, next) => {
         leaderboard: users.map((u) => u.getBaseProfile()),
       });
       return null;
+    })
+    .catch(next);
+});
+
+/**
+ * Filtered leaderboard for officers and admins.
+ * Returns user profiles sorted by points, filtered by the caller's
+ * permissions (see buildAdminLeaderboardQuery).
+ *
+ * Query params: ?year, ?role, ?committee
+ */
+router.route('/admin').get(isOfficerOrAdmin, (req, res, next) => {
+  const where = buildAdminLeaderboardQuery(req.query, req.user);
+
+  return User.findAll({
+    where,
+    order: [['points', 'DESC']],
+  })
+    .then((users) => {
+      res.json({
+        error: null,
+        leaderboard: users.map((u) => u.getBaseProfile()),
+      });
     })
     .catch(next);
 });

--- a/tests/admin-leaderboard.test.js
+++ b/tests/admin-leaderboard.test.js
@@ -1,0 +1,183 @@
+import request from 'supertest';
+import { server, setup } from '..';
+
+const jwt = require('jsonwebtoken');
+const { User } = require('../app/db');
+const config = require('../app/config');
+
+const API_ROUTE = '/app/api/v1/';
+const route = (name) => API_ROUTE + name;
+
+const getJWTToken = (user) => new Promise((res, rej) => {
+  jwt.sign(
+    {
+      uuid: user.getDataValue('uuid'),
+      admin: user.isAdmin(),
+      superAdmin: user.isSuperAdmin(),
+      officer: user.isOfficer(),
+      registered: !user.isPending(),
+    },
+    config.session.secret,
+    { expiresIn: 3600 },
+    (err, jwtToken) => {
+      if (err) rej(err);
+      res(jwtToken);
+    },
+  );
+});
+
+beforeAll(async () => {
+  await setup;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('GET /leaderboard/admin', () => {
+  let adminUser;
+  let adminToken;
+  let officerUser;
+  let officerToken;
+  let standardUser;
+  let standardToken;
+  let memberYear3;
+  let hackOfficer;
+
+  beforeEach(async () => {
+    adminUser = await User.create({
+      email: `admin-${Date.now()}@test.com`,
+      firstName: 'Admin',
+      lastName: 'User',
+      accessType: 'ADMIN',
+      state: 'ACTIVE',
+      year: 4,
+      major: 'CS',
+    });
+    adminToken = await getJWTToken(adminUser);
+
+    officerUser = await User.create({
+      email: `officer-${Date.now()}@test.com`,
+      firstName: 'Officer',
+      lastName: 'User',
+      accessType: 'OFFICER',
+      state: 'ACTIVE',
+      year: 3,
+      major: 'CS',
+      committees: ['AI'],
+    });
+    officerToken = await getJWTToken(officerUser);
+
+    standardUser = await User.create({
+      email: `standard-${Date.now()}@test.com`,
+      firstName: 'Standard',
+      lastName: 'User',
+      accessType: 'STANDARD',
+      state: 'ACTIVE',
+      year: 2,
+      major: 'Math',
+    });
+    standardToken = await getJWTToken(standardUser);
+
+    memberYear3 = await User.create({
+      email: `year3-${Date.now()}@test.com`,
+      firstName: 'Year3',
+      lastName: 'Member',
+      accessType: 'STANDARD',
+      state: 'ACTIVE',
+      year: 3,
+      major: 'CS',
+    });
+
+    hackOfficer = await User.create({
+      email: `hack-officer-${Date.now()}@test.com`,
+      firstName: 'Hack',
+      lastName: 'Officer',
+      accessType: 'OFFICER',
+      state: 'ACTIVE',
+      year: 2,
+      major: 'CS',
+      committees: ['Hack'],
+    });
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      adminUser.destroy(),
+      officerUser.destroy(),
+      standardUser.destroy(),
+      memberYear3.destroy(),
+      hackOfficer.destroy(),
+    ]);
+  });
+
+  test('standard user gets 403', async () => {
+    const res = await request(server)
+      .get(route('leaderboard/admin'))
+      .auth(standardToken, { type: 'bearer' });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('unauthenticated gets 401', async () => {
+    const res = await request(server).get(route('leaderboard/admin'));
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('officer sees only STANDARD users by default', async () => {
+    const res = await request(server)
+      .get(route('leaderboard/admin'))
+      .auth(officerToken, { type: 'bearer' });
+    expect(res.statusCode).toBe(200);
+    const types = res.body.leaderboard.map((u) => u.accessType);
+    types.forEach((t) => expect(t).toBeUndefined());
+    expect(res.body.total).toBeGreaterThanOrEqual(1);
+  });
+
+  test('admin sees all access types by default', async () => {
+    const res = await request(server)
+      .get(route('leaderboard/admin'))
+      .auth(adminToken, { type: 'bearer' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.total).toBeGreaterThanOrEqual(3);
+  });
+
+  test('officer can filter by year', async () => {
+    const res = await request(server)
+      .get(route('leaderboard/admin?year=3'))
+      .auth(officerToken, { type: 'bearer' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.leaderboard.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('officer cannot filter by role (ignored)', async () => {
+    const res = await request(server)
+      .get(route('leaderboard/admin?role=ADMIN'))
+      .auth(officerToken, { type: 'bearer' });
+    expect(res.statusCode).toBe(200);
+  });
+
+  test('officer cannot filter by committee (ignored)', async () => {
+    const res = await request(server)
+      .get(route('leaderboard/admin?committee=Hack'))
+      .auth(officerToken, { type: 'bearer' });
+    expect(res.statusCode).toBe(200);
+  });
+
+  test('admin can filter by role=MEMBER', async () => {
+    const res = await request(server)
+      .get(route('leaderboard/admin?role=MEMBER'))
+      .auth(adminToken, { type: 'bearer' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.leaderboard.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('admin can filter by committee', async () => {
+    const res = await request(server)
+      .get(route('leaderboard/admin?committee=Hack'))
+      .auth(adminToken, { type: 'bearer' });
+    expect(res.statusCode).toBe(200);
+    const names = res.body.leaderboard.map((u) => u.firstName);
+    expect(names).toContain('Hack');
+  });
+
+});


### PR DESCRIPTION
## Description

Add a new `/leaderboard/admin` endpoint with role-based query parameter filtering for the admin/officer leaderboard view.

### New files
- `admin-filters.js` — Shared `buildAdminLeaderboardQuery` function that builds a Sequelize `where` clause based on the caller's role and query params. Officers are restricted to `STANDARD` members only; admins can query all access types.
- `admin-leaderboard.test.js` — 9 tests covering auth (`401`/`403`), default visibility per role, and all filter combinations.

### Modified files
- `leaderboard/index.js` — New `/admin` route behind `isOfficerOrAdmin` middleware.

---

## Permission Model

### Officers
- Can filter by `?year=` only
- `role` and `committee` params are silently ignored
- Always scoped to `STANDARD` members

### Admins
- Can filter by:
  - `?year=`
  - `?role=`
  - `?committee=`
- Sees all access types by default

---

## Resolves 
- Issue [#282](https://github.com/uclaacm/membership-portal-ui/issues/282) in membership-portal-ui
- See the frontend PR [here](https://github.com/uclaacm/membership-portal-ui/pull/345)
---

## Steps to View & Test Changes

- As a standard user:
  - `GET /leaderboard/admin` → expect `403`

- As an officer:
  - `GET /leaderboard/admin` → expect only `STANDARD` members returned
  - `GET /leaderboard/admin?year=3` → expect only year 3 `STANDARD`
    members
  - `GET /leaderboard/admin?role=ADMIN` → expect the `role` param to be
    ignored (still returns `STANDARD` only)

- As an admin:
  - `GET /leaderboard/admin` → expect all users returned
  - `GET /leaderboard/admin?role=MEMBER` → expect only `STANDARD`
    members
  - `GET /leaderboard/admin?committee=Hack` → expect only members of the
    `Hack` committee

- Unauthenticated request:
  - `GET /leaderboard/admin` → expect `401`

---

## How Has This Been Tested?

- [x] 9 backend unit tests covering:
  - Auth validation
  - Default visibility rules
  - `year` / `role` / `committee` filtering
  - Officer restriction enforcement