### PR TITLE
Feat/internship cycle mgmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node.env
 pg_bkup*
 .DS_Store
 .vscode
+postman
+.postman*

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ setup:
 	fi
 	$(MAKE) migrate
 
+seed-internship-test-data:
+	node scripts/seed-internship-test-data.js
+
 ash:
 	docker run -v $(pwd):/app -p "8080:8080" $(APP_NAME) /bin/ash
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ setup:
 seed-internship-test-data:
 	node scripts/seed-internship-test-data.js
 
+seed-officer-test-applications:
+	node scripts/seed-officer-test-applications.js
+
 ash:
 	docker run -v $(pwd):/app -p "8080:8080" $(APP_NAME) /bin/ash
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ To run in development:
 $ make
 ```
 
+### Internship Test Data
+The normal dev setup seeds Postgres users, committees, and events, but internship applications live in MongoDB and are not seeded automatically.
+
+To create or refresh internship testing data for a local member account:
+```Bash
+$ SEED_EMAIL=myusername@g.ucla.edu SEED_STATUS=draft make seed-internship-test-data
+```
+
+Useful overrides:
+* `SEED_EMAIL` - Postgres user email to seed for.
+* `SEED_USER_UUID` - Postgres user UUID to seed for. Use this if you already know the database UUID.
+* `SEED_STATUS` - `draft` or `submitted`.
+* `SEED_COMMITTEES` - Comma-separated committee names, default `Hack,AI,Design`.
+* `SEED_APPLICATION_CYCLE` - Target application cycle, default current cycle.
+
+If you do not pass `SEED_EMAIL` or `SEED_USER_UUID`, the script will fail instead of silently seeding a different user.
+
 ### Testing
 
 To run unit tests:

--- a/app/api/v1/internship/controllers/applicationController.js
+++ b/app/api/v1/internship/controllers/applicationController.js
@@ -15,20 +15,37 @@ const CHOICE_FIELDS = [
     committeeField: 'firstChoiceCommittee',
     responsesField: 'firstChoiceResponses',
     statusField: 'firstChoiceStatus',
+    officer1RatingField: 'firstChoiceOfficer1Rating',
+    officer2RatingField: 'firstChoiceOfficer2Rating',
+    notesField: 'firstChoiceNotes',
   },
   {
     label: 'second choice',
     committeeField: 'secondChoiceCommittee',
     responsesField: 'secondChoiceResponses',
     statusField: 'secondChoiceStatus',
+    officer1RatingField: 'secondChoiceOfficer1Rating',
+    officer2RatingField: 'secondChoiceOfficer2Rating',
+    notesField: 'secondChoiceNotes',
   },
   {
     label: 'third choice',
     committeeField: 'thirdChoiceCommittee',
     responsesField: 'thirdChoiceResponses',
     statusField: 'thirdChoiceStatus',
+    officer1RatingField: 'thirdChoiceOfficer1Rating',
+    officer2RatingField: 'thirdChoiceOfficer2Rating',
+    notesField: 'thirdChoiceNotes',
   },
 ];
+
+function getChoiceForReviewField(reviewField) {
+  return CHOICE_FIELDS.find((choice) => (
+    choice.officer1RatingField === reviewField
+    || choice.officer2RatingField === reviewField
+    || choice.notesField === reviewField
+  ));
+}
 
 function getOfficerCommittees(user) {
   if (!user) {
@@ -58,6 +75,34 @@ function officerCanManageCommittee(user, committee) {
 
 function buildMissingFieldsMessage(missingFields) {
   return `Missing required fields: ${missingFields.join(', ')}`;
+}
+
+// Strip response arrays for any committee choice the officer doesn't manage,
+// so answers written for other committees never reach an officer's browser
+// (not just hidden in the UI — removed from the API response itself).
+function scrubResponsesForOfficer(application, ownedCommitteeIds) {
+  const plain = typeof application.toObject === 'function' ? application.toObject() : { ...application };
+  const ownedIds = new Set(ownedCommitteeIds.map((id) => id.toString()));
+
+  CHOICE_FIELDS.forEach((choice) => {
+    const committeeId = plain[choice.committeeField];
+    const isOwned = committeeId && ownedIds.has(committeeId.toString());
+    if (!isOwned) {
+      plain[choice.responsesField] = [];
+      plain[choice.officer1RatingField] = null;
+      plain[choice.officer2RatingField] = null;
+      plain[choice.notesField] = '';
+    }
+  });
+
+  return plain;
+}
+
+async function getOfficerCommitteeIds(user) {
+  const allCommittees = await Committee.find({}).select('name displayName');
+  return allCommittees
+    .filter((committee) => officerCanManageCommittee(user, committee))
+    .map((committee) => committee.id);
 }
 
 // Create a new internship application
@@ -203,23 +248,24 @@ async function getAllApplications(req, res) {
     const isAdmin = typeof req.user.isAdmin === 'function' && req.user.isAdmin();
     const includeDrafts = isAdmin && req.query.includeDrafts === 'true';
 
+    let officerCommitteeIds = null;
+
     if (isOfficer && !isAdmin) {
-      const officerCommittees = req.user.getDataValue ? (req.user.getDataValue('committees') || []) : (req.user.committees || []);
+      const officerCommittees = getOfficerCommittees(req.user);
       if (!officerCommittees.length) {
         return res.json({ success: true, data: [], pagination: { total: 0 } });
       }
 
-      // Fetch committee ObjectIds matching officer's committee names (case-insensitive)
-      const committees = await Committee.find({
-        name: { $in: officerCommittees.map((c) => c.toLowerCase()) },
-      });
-      const committeeIds = committees.map((c) => c.id);
+      // Fetch committee ObjectIds matching officer's committee names (case-insensitive).
+      // Comparing lowercased names directly against Committee.name would silently match
+      // nothing, since committee names are stored in display casing (e.g. "ICPC").
+      officerCommitteeIds = await getOfficerCommitteeIds(req.user);
 
       // Scope query: application must have at least one choice in officer's committees
       query.$or = [
-        { firstChoiceCommittee: { $in: committeeIds } },
-        { secondChoiceCommittee: { $in: committeeIds } },
-        { thirdChoiceCommittee: { $in: committeeIds } },
+        { firstChoiceCommittee: { $in: officerCommitteeIds } },
+        { secondChoiceCommittee: { $in: officerCommitteeIds } },
+        { thirdChoiceCommittee: { $in: officerCommitteeIds } },
       ];
     }
 
@@ -271,9 +317,13 @@ async function getAllApplications(req, res) {
 
     const total = await InternshipApplication.countDocuments(query);
 
+    const data = officerCommitteeIds
+      ? applications.map((app) => scrubResponsesForOfficer(app, officerCommitteeIds))
+      : applications;
+
     return res.status(200).json({
       success: true,
-      data: applications,
+      data,
       pagination: {
         page: pageNum,
         limit: limitNum,
@@ -299,6 +349,32 @@ async function getApplicationById(req, res) {
       res.status(404).json({
         success: false,
         message: 'Application not found',
+      });
+      return;
+    }
+
+    const isAdmin = typeof req.user.isAdmin === 'function' && req.user.isAdmin();
+    const isOfficer = typeof req.user.isOfficer === 'function' && req.user.isOfficer();
+
+    if (isOfficer && !isAdmin) {
+      const officerCommitteeIds = await getOfficerCommitteeIds(req.user);
+      const ownedIds = new Set(officerCommitteeIds.map((id) => id.toString()));
+      const hasAccess = CHOICE_FIELDS.some((choice) => {
+        const committeeId = application[choice.committeeField];
+        return committeeId && ownedIds.has(committeeId.toString());
+      });
+
+      if (!hasAccess) {
+        res.status(403).json({
+          success: false,
+          message: 'You do not have permission to view this application',
+        });
+        return;
+      }
+
+      res.status(200).json({
+        success: true,
+        data: scrubResponsesForOfficer(application, officerCommitteeIds),
       });
       return;
     }
@@ -522,9 +598,13 @@ async function updateApplicationStatus(req, res) {
       { new: true, runValidators: true },
     );
 
+    const data = (isOfficer && !isAdmin)
+      ? scrubResponsesForOfficer(updatedApp, [committee.id])
+      : updatedApp;
+
     return res.status(200).json({
       success: true,
-      data: updatedApp,
+      data,
       message: 'Application status updated successfully',
     });
   } catch (error) {
@@ -538,6 +618,104 @@ async function updateApplicationStatus(req, res) {
     return res.status(500).json({
       success: false,
       message: 'Error updating application status',
+      error: error.message,
+    });
+  }
+}
+
+// Update one officer-review field (either officer's yes/no rating, or the
+// shared notes) for one committee choice on a submitted application.
+async function updateApplicationReview(req, res) {
+  try {
+    const { reviewField, value } = req.body;
+    const choice = getChoiceForReviewField(reviewField);
+
+    if (!choice) {
+      return res.status(400).json({
+        success: false,
+        message: 'Invalid review field',
+      });
+    }
+
+    const application = await InternshipApplication.findById(req.params.id);
+    if (!application || application.deletedAt) {
+      return res.status(404).json({
+        success: false,
+        message: 'Application not found',
+      });
+    }
+
+    if (application.submissionStatus !== 'submitted') {
+      return res.status(400).json({
+        success: false,
+        message: 'Application review fields can only be set after submission',
+      });
+    }
+
+    const committeeId = application[choice.committeeField];
+    if (!committeeId) {
+      return res.status(400).json({
+        success: false,
+        message: `Application does not include a ${choice.label} committee`,
+      });
+    }
+
+    const committee = await Committee.findById(committeeId)
+      .select('name displayName');
+    if (!committee) {
+      return res.status(400).json({
+        success: false,
+        message: `${choice.label} committee no longer exists`,
+      });
+    }
+
+    const isAdmin = typeof req.user.isAdmin === 'function' && req.user.isAdmin();
+    const isOfficer = typeof req.user.isOfficer === 'function' && req.user.isOfficer();
+
+    if (!isAdmin && (!isOfficer || !officerCanManageCommittee(req.user, committee))) {
+      return res.status(403).json({
+        success: false,
+        message: `You do not have permission to update ${choice.label} review details`,
+      });
+    }
+
+    let normalizedValue;
+    if (reviewField === choice.notesField) {
+      normalizedValue = typeof value === 'string' ? value.trim() : '';
+    } else {
+      normalizedValue = value || null;
+    }
+
+    const lastModifiedAt = new Date();
+    const updatedApp = await InternshipApplication.findByIdAndUpdate(
+      req.params.id,
+      {
+        [reviewField]: normalizedValue,
+        lastModifiedAt,
+      },
+      { new: true, runValidators: true },
+    );
+
+    const data = (isOfficer && !isAdmin)
+      ? scrubResponsesForOfficer(updatedApp, [committee.id])
+      : updatedApp;
+
+    return res.status(200).json({
+      success: true,
+      data,
+      message: 'Application review updated successfully',
+    });
+  } catch (error) {
+    if (error.name === 'ValidationError') {
+      return res.status(400).json({
+        success: false,
+        message: 'Validation error',
+        errors: error.errors,
+      });
+    }
+    return res.status(500).json({
+      success: false,
+      message: 'Error updating application review',
       error: error.message,
     });
   }
@@ -674,6 +852,7 @@ module.exports = {
   getApplicationById,
   updateApplication,
   updateApplicationStatus,
+  updateApplicationReview,
   deleteApplication,
   getOwnApplication,
   submitApplication,

--- a/app/api/v1/internship/controllers/applicationController.js
+++ b/app/api/v1/internship/controllers/applicationController.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const {
   InternshipApplication,
   getCurrentApplicationCycle,
@@ -108,7 +109,7 @@ async function getOfficerCommitteeIds(user) {
 // Create a new internship application
 async function createApplication(req, res) {
   try {
-    const applicationCycle = getCurrentApplicationCycle();
+    const applicationCycle = await getCurrentApplicationCycle();
 
     const existingApplication = await InternshipApplication.findOne({
       userId: req.user.uuid,
@@ -236,12 +237,21 @@ async function getAllApplications(req, res) {
       thirdChoiceCommittee,
       applicationCycle,
       userId,
+      search,
+      archived,
+      committeeId,
+      status,
+      choiceRank,
       page = 1,
       limit = 10,
     } = req.query;
 
     // Build query object with validated parameters
     const query = {};
+    // Committee-scope (officer auto-scope, or an explicit committeeId
+    // filter) and free-text search each need their own $or clause; collect
+    // them here and combine via $and so neither clobbers the other.
+    const andConditions = [];
 
     // Officer scoping logic
     const isOfficer = typeof req.user.isOfficer === 'function' && req.user.isOfficer();
@@ -249,6 +259,7 @@ async function getAllApplications(req, res) {
     const includeDrafts = isAdmin && req.query.includeDrafts === 'true';
 
     let officerCommitteeIds = null;
+    let committeeCondition = null;
 
     if (isOfficer && !isAdmin) {
       const officerCommittees = getOfficerCommittees(req.user);
@@ -260,17 +271,68 @@ async function getAllApplications(req, res) {
       // Comparing lowercased names directly against Committee.name would silently match
       // nothing, since committee names are stored in display casing (e.g. "ICPC").
       officerCommitteeIds = await getOfficerCommitteeIds(req.user);
+      committeeCondition = { $in: officerCommitteeIds };
+    } else if (committeeId && typeof committeeId === 'string') {
+      // "This application chose committee X in any of its 3 choice slots" —
+      // distinct from the strict per-slot firstChoiceCommittee/etc. filters
+      // below, which match one specific slot. Since the 3 slots can never
+      // repeat the same committee, an equality filter on all 3 at once would
+      // never match anything; this is the correct "any slot" filter.
+      committeeCondition = committeeId;
+    }
 
-      // Scope query: application must have at least one choice in officer's committees
-      query.$or = [
-        { firstChoiceCommittee: { $in: officerCommitteeIds } },
-        { secondChoiceCommittee: { $in: officerCommitteeIds } },
-        { thirdChoiceCommittee: { $in: officerCommitteeIds } },
-      ];
+    // "This application's committee-matching slot (see committeeCondition
+    // above) also has status X" — status must be paired with committee
+    // scope PER SLOT, not as an independent "any slot has status X" clause.
+    // Otherwise "committee A, status reviewing" could wrongly match an
+    // application where committee A's own slot is "accepted" but some other,
+    // unrelated slot happens to be "reviewing".
+    const hasStatusFilter = status && typeof status === 'string';
+    // choiceRank ("1"|"2"|"3") restricts matching to one specific slot
+    // instead of "any slot" — used by the officer dashboard's choice-rank
+    // filter, since an officer only cares about the single slot (if any)
+    // that's their own committee.
+    const choiceSlots = ['1', '2', '3'].includes(choiceRank)
+      ? [CHOICE_FIELDS[Number(choiceRank) - 1]]
+      : CHOICE_FIELDS;
+    const hasChoiceRankFilter = choiceSlots.length < CHOICE_FIELDS.length;
+    if (committeeCondition !== null || hasStatusFilter || hasChoiceRankFilter) {
+      andConditions.push({
+        $or: choiceSlots.map(({ committeeField, statusField }) => {
+          const clause = {};
+          if (committeeCondition !== null) clause[committeeField] = committeeCondition;
+          if (hasStatusFilter) clause[statusField] = status;
+          return clause;
+        }),
+      });
+    }
+
+    // Free-text search over applicant name/email
+    if (search && typeof search === 'string') {
+      const escapedSearch = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const searchRegex = new RegExp(escapedSearch, 'i');
+      andConditions.push({
+        $or: [
+          { firstName: searchRegex },
+          { lastName: searchRegex },
+          { email: searchRegex },
+        ],
+      });
+    }
+
+    if (andConditions.length === 1) {
+      Object.assign(query, andConditions[0]);
+    } else if (andConditions.length > 1) {
+      query.$and = andConditions;
     }
 
     // Always exclude soft-deleted records
     query.deletedAt = null;
+
+    // Archived applications (a past, closed cycle) are hidden from the
+    // default view; ?archived=true switches to the read-only past-cycles
+    // view showing only archived applications.
+    query.archivedAt = archived === true || archived === 'true' ? { $ne: null } : null;
 
     // Officers should not see drafts; admins can opt in
     if (!includeDrafts) {
@@ -340,6 +402,79 @@ async function getAllApplications(req, res) {
   }
 }
 
+// Per-status counts across ALL of a committee's current, non-archived,
+// submitted applications (not just one page) — "my status" is whichever
+// slot's committee matches, mirroring the officer dashboard's
+// enrichForCommittee logic. Powers the officer dashboard's stats pills,
+// which need true totals independent of the current page/filters.
+async function getApplicationStatusCounts(req, res) {
+  try {
+    const isOfficer = typeof req.user.isOfficer === 'function' && req.user.isOfficer();
+    const isAdmin = typeof req.user.isAdmin === 'function' && req.user.isAdmin();
+
+    let committeeIds;
+    if (isOfficer && !isAdmin) {
+      committeeIds = await getOfficerCommitteeIds(req.user);
+    } else if (isAdmin && req.query.committeeId) {
+      committeeIds = [req.query.committeeId];
+    } else {
+      return res.status(400).json({ success: false, message: 'committeeId is required for admin requests' });
+    }
+
+    if (!committeeIds.length) {
+      return res.json({ success: true, counts: {} });
+    }
+
+    const committeeObjectIds = committeeIds.map(
+      (id) => (typeof id === 'string' ? new mongoose.Types.ObjectId(id) : id),
+    );
+
+    const results = await InternshipApplication.aggregate([
+      {
+        $match: {
+          deletedAt: null,
+          archivedAt: null,
+          submissionStatus: 'submitted',
+          $or: [
+            { firstChoiceCommittee: { $in: committeeObjectIds } },
+            { secondChoiceCommittee: { $in: committeeObjectIds } },
+            { thirdChoiceCommittee: { $in: committeeObjectIds } },
+          ],
+        },
+      },
+      {
+        $addFields: {
+          myStatus: {
+            $switch: {
+              branches: [
+                { case: { $in: ['$firstChoiceCommittee', committeeObjectIds] }, then: '$firstChoiceStatus' },
+                { case: { $in: ['$secondChoiceCommittee', committeeObjectIds] }, then: '$secondChoiceStatus' },
+                { case: { $in: ['$thirdChoiceCommittee', committeeObjectIds] }, then: '$thirdChoiceStatus' },
+              ],
+              default: null,
+            },
+          },
+        },
+      },
+      { $match: { myStatus: { $ne: null } } },
+      { $group: { _id: '$myStatus', count: { $sum: 1 } } },
+    ]);
+
+    const counts = {};
+    results.forEach((row) => {
+      counts[row._id] = row.count;
+    });
+
+    return res.json({ success: true, counts });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: 'Error fetching application status counts',
+      error: error.message,
+    });
+  }
+}
+
 // Get a single internship application by ID
 async function getApplicationById(req, res) {
   try {
@@ -395,7 +530,7 @@ async function getApplicationById(req, res) {
 // Get the authenticated user's own application
 async function getOwnApplication(req, res) {
   try {
-    const applicationCycle = getCurrentApplicationCycle();
+    const applicationCycle = await getCurrentApplicationCycle();
     const application = await InternshipApplication.findOne({
       userId: req.user.uuid,
       applicationCycle,
@@ -849,6 +984,7 @@ async function submitApplication(req, res) {
 module.exports = {
   createApplication,
   getAllApplications,
+  getApplicationStatusCounts,
   getApplicationById,
   updateApplication,
   updateApplicationStatus,

--- a/app/api/v1/internship/controllers/committeeController.js
+++ b/app/api/v1/internship/controllers/committeeController.js
@@ -1,13 +1,15 @@
 const { Committee } = require('../models/Committee');
 const { InternshipApplication } = require('../models/InternshipApplication');
 const { canManageCommitteeResource } = require('../../auth/committeeScope');
+const { getCurrentCycle } = require('../models/InternshipSettings');
 const error = require('../../../../error');
 
-// Count submitted (non-deleted) applications per committee across all 3 choice slots.
-// $setUnion dedupes per application so a committee selected in multiple slots only counts once.
+// Count submitted (non-deleted, non-archived) applications per committee across all 3 choice
+// slots. $setUnion dedupes per application so a committee selected in multiple slots only
+// counts once.
 async function getApplicationCountsByCommittee() {
   const counts = await InternshipApplication.aggregate([
-    { $match: { deletedAt: null, submissionStatus: 'submitted' } },
+    { $match: { deletedAt: null, archivedAt: null, submissionStatus: 'submitted' } },
     {
       $project: {
         committees: {
@@ -33,7 +35,7 @@ async function getApplicationCountsByCommittee() {
 async function getAllCommittees(req, res, next) {
   try {
     const includeInactive = req.query.includeInactive === 'true' && req.user && req.user.isAdmin();
-    const filter = {};
+    const filter = includeInactive ? {} : { isActive: true };
 
     const committees = await Committee.find(filter).select('-__v').sort({ displayName: 1 });
 
@@ -126,6 +128,41 @@ async function deleteCommittee(req, res, next) {
   }
 }
 
+// Archives this committee's current-cycle applications. The committee
+// document itself is never modified — it persists exactly as-is; it just
+// has no current-cycle applications after this runs.
+async function archiveCommittee(req, res, next) {
+  try {
+    const committee = await Committee.findById(req.params.id);
+    if (!committee) {
+      return res.status(404).json({ error: 'Committee not found' });
+    }
+
+    const currentCycle = await getCurrentCycle();
+
+    const result = await InternshipApplication.updateMany(
+      {
+        $or: [
+          { firstChoiceCommittee: committee._id },
+          { secondChoiceCommittee: committee._id },
+          { thirdChoiceCommittee: committee._id },
+        ],
+        applicationCycle: currentCycle,
+        deletedAt: null,
+        archivedAt: null,
+      },
+      { $set: { archivedAt: new Date(), archivedBy: req.user.uuid } },
+    );
+    const archivedCount = (result && (
+      result.modifiedCount !== undefined ? result.modifiedCount : result.nModified
+    )) || 0;
+
+    return res.json({ error: null, archivedCount });
+  } catch (e) {
+    return next(e);
+  }
+}
+
 async function bulkUpdateCommitteeStatus(req, res, next) {
   try {
     const { action, committeeIds } = req.body;
@@ -179,5 +216,6 @@ module.exports = {
   updateCommitteeQuestions,
   updateCommitteeAdmin,
   deleteCommittee,
+  archiveCommittee,
   bulkUpdateCommitteeStatus,
 };

--- a/app/api/v1/internship/controllers/cycleController.js
+++ b/app/api/v1/internship/controllers/cycleController.js
@@ -1,0 +1,76 @@
+const { InternshipApplication } = require('../models/InternshipApplication');
+const {
+  computeDefaultCycleLabel,
+  getCurrentCycle,
+  setCurrentCycle,
+} = require('../models/InternshipSettings');
+const error = require('../../../../error');
+
+// Bumps a "YYYY-YYYY+1" cycle label forward by one year. Falls back to a
+// fresh calendar-based label if the current cycle isn't in that shape (e.g.
+// an admin previously set a custom label).
+function suggestNextCycle(currentCycle) {
+  const match = /^(\d{4})-(\d{4})$/.exec(currentCycle);
+  if (!match) {
+    return computeDefaultCycleLabel();
+  }
+  const startYear = Number(match[1]);
+  return `${startYear + 1}-${startYear + 2}`;
+}
+
+async function getCycleInfo(req, res, next) {
+  try {
+    const currentCycle = await getCurrentCycle();
+    const pastCycles = await InternshipApplication.distinct('applicationCycle', {
+      applicationCycle: { $ne: currentCycle },
+    });
+
+    return res.json({
+      error: null,
+      currentCycle,
+      suggestedNextCycle: suggestNextCycle(currentCycle),
+      pastCycles: pastCycles.sort(),
+    });
+  } catch (e) {
+    return next(e);
+  }
+}
+
+// Archives every committee's current-cycle applications and advances the
+// stored "current" cycle. Committee documents are never touched by this —
+// they persist unchanged; they just have no current-cycle applications
+// after this runs.
+async function advanceCycle(req, res, next) {
+  try {
+    const previousCycle = await getCurrentCycle();
+    const newCycle = (req.body && req.body.newCycle) || suggestNextCycle(previousCycle);
+
+    if (typeof newCycle !== 'string' || !newCycle.trim()) {
+      throw new error.BadRequest('newCycle must be a non-empty string.');
+    }
+    if (newCycle === previousCycle) {
+      throw new error.BadRequest('newCycle must be different from the current cycle.');
+    }
+
+    const result = await InternshipApplication.updateMany(
+      { applicationCycle: previousCycle, deletedAt: null, archivedAt: null },
+      { $set: { archivedAt: new Date(), archivedBy: req.user.uuid } },
+    );
+    const archivedCount = (result && (
+      result.modifiedCount !== undefined ? result.modifiedCount : result.nModified
+    )) || 0;
+
+    await setCurrentCycle(newCycle);
+
+    return res.json({
+      error: null, previousCycle, newCycle, archivedCount,
+    });
+  } catch (e) {
+    return next(e);
+  }
+}
+
+module.exports = {
+  getCycleInfo,
+  advanceCycle,
+};

--- a/app/api/v1/internship/index.js
+++ b/app/api/v1/internship/index.js
@@ -8,6 +8,7 @@ const adminOrOfficer = require('../auth').isOfficerOrAdmin;
 const {
   createApplication,
   getAllApplications,
+  getApplicationStatusCounts,
   getApplicationById,
   updateApplication,
   updateApplicationStatus,
@@ -24,8 +25,10 @@ const {
   updateCommitteeQuestions,
   updateCommitteeAdmin,
   deleteCommittee,
+  archiveCommittee,
   bulkUpdateCommitteeStatus,
 } = require('./controllers/committeeController');
+const { getCycleInfo, advanceCycle } = require('./controllers/cycleController');
 const {
   validateCreateApplication,
   validateUpdateApplication,
@@ -43,6 +46,9 @@ router.get('/applications', auth, adminOrOfficer, getApplicationsLimiter, valida
 
 // GET own application (authenticated non-admin user)
 router.get('/applications/me', auth, getApplicationsLimiter, getOwnApplication);
+
+// GET per-status application counts for a committee (officers and admins) - must be before /:id
+router.get('/applications/status-counts', auth, adminOrOfficer, getApplicationsLimiter, getApplicationStatusCounts);
 
 // GET a single application by ID (officers only)
 router.get('/applications/:id', auth, officer, getApplicationsLimiter, getApplicationById);
@@ -90,5 +96,14 @@ router.put('/committees/:id/questions', auth, adminOrOfficer, committeeRateLimit
 
 // DELETE committee (admin only) - soft delete by setting isActive to false
 router.delete('/committees/:id', auth, admin, deleteCommittee);
+
+// ARCHIVE a committee's current-cycle applications (admin only)
+router.post('/committees/:id/archive', auth, admin, committeeRateLimiter, archiveCommittee);
+
+// GET the current/past application cycle info (admin only)
+router.get('/cycle', auth, admin, getCycleInfo);
+
+// POST advance to a new application cycle, archiving the outgoing cycle (admin only)
+router.post('/cycle/advance', auth, admin, committeeRateLimiter, advanceCycle);
 
 module.exports = { router };

--- a/app/api/v1/internship/index.js
+++ b/app/api/v1/internship/index.js
@@ -11,6 +11,7 @@ const {
   getApplicationById,
   updateApplication,
   updateApplicationStatus,
+  updateApplicationReview,
   deleteApplication,
   getOwnApplication,
   submitApplication,
@@ -29,6 +30,7 @@ const {
   validateCreateApplication,
   validateUpdateApplication,
   validateUpdateApplicationStatus,
+  validateUpdateApplicationReview,
   validateGetApplications,
   validateMongoId,
 } = require('./middleware/validation');
@@ -54,6 +56,9 @@ router.put('/applications/:id', auth, validateUpdateApplication, updateApplicati
 
 // PUT update review status for one committee choice (officers/admins only)
 router.put('/applications/:id/status', auth, adminOrOfficer, validateUpdateApplicationStatus, updateApplicationStatus);
+
+// PUT update an officer review field (yes/no rating or notes) for one committee choice
+router.put('/applications/:id/review', auth, adminOrOfficer, validateUpdateApplicationReview, updateApplicationReview);
 
 // POST submit a draft application (member+)
 router.post('/applications/:id/submit', auth, strictCreateApplicationLimiter, validateMongoId, submitApplication);

--- a/app/api/v1/internship/middleware/validation.js
+++ b/app/api/v1/internship/middleware/validation.js
@@ -50,19 +50,13 @@ async function validateCommitteeResponses(committeeId, responses, fieldLabel) {
     throw new Error(`Invalid ${fieldLabel} committee selection`);
   }
 
-  const requiredQuestions = committee.customQuestions.filter((q) => q.required);
   const responseList = Array.isArray(responses) ? responses : [];
   const answeredQuestionKeys = responseList.map((r) => r.questionKey);
 
-  if (requiredQuestions.length > 0) {
-    const missingQuestions = requiredQuestions.filter(
-      (q) => !answeredQuestionKeys.includes(q.questionKey),
-    );
-    if (missingQuestions.length > 0) {
-      const missing = missingQuestions.map((q) => q.questionText).join(', ');
-      throw new Error(`Missing required questions for ${fieldLabel} committee: ${missing}`);
-    }
-  }
+  // Required-question completeness is enforced at submission time (see
+  // submitApplication in applicationController.js), not at draft creation —
+  // Step 1 of the wizard creates the draft from just a committee choice,
+  // before the user has answered any custom questions in Step 2.
 
   const validQuestionMap = new Map(
     committee.customQuestions.map((q) => [q.questionKey, q]),

--- a/app/api/v1/internship/middleware/validation.js
+++ b/app/api/v1/internship/middleware/validation.js
@@ -334,6 +334,15 @@ const validateGetApplications = [
     .withMessage('Third choice committee must be a valid MongoDB ID'),
   query('applicationCycle').optional().trim(),
   query('userId').optional().trim(),
+  query('search').optional().trim()
+    .isLength({ max: 100 })
+    .withMessage('Search must be 100 characters or fewer'),
+  query('archived').optional().isBoolean()
+    .withMessage('archived must be a boolean')
+    .toBoolean(),
+  query('committeeId').optional().isMongoId().withMessage('committeeId must be a valid MongoDB ID'),
+  query('status').optional().isIn(STATUS_OPTIONS).withMessage('Invalid status filter'),
+  query('choiceRank').optional().isIn(['1', '2', '3']).withMessage('choiceRank must be 1, 2, or 3'),
   query('page').optional().isInt({ min: 1 }).withMessage('Page must be a positive integer'),
   query('limit')
     .optional()

--- a/app/api/v1/internship/middleware/validation.js
+++ b/app/api/v1/internship/middleware/validation.js
@@ -17,6 +17,21 @@ const STATUS_FIELD_OPTIONS = [
   'thirdChoiceStatus',
 ];
 
+const REVIEW_FIELD_OPTIONS = [
+  'firstChoiceOfficer1Rating',
+  'secondChoiceOfficer1Rating',
+  'thirdChoiceOfficer1Rating',
+  'firstChoiceOfficer2Rating',
+  'secondChoiceOfficer2Rating',
+  'thirdChoiceOfficer2Rating',
+  'firstChoiceNotes',
+  'secondChoiceNotes',
+  'thirdChoiceNotes',
+];
+
+const RATING_OPTIONS = ['yes', 'no', 'maybe'];
+const NOTES_MAX_LENGTH = 2000;
+
 const EMAIL_REGEX = /^\S+@(ucla\.edu|g\.ucla\.edu)$/;
 
 async function validateCommitteeById(value, fieldLabel) {
@@ -266,6 +281,37 @@ const validateUpdateApplicationStatus = [
   handleValidationErrors,
 ];
 
+// Validate officer review field update (yes/no ratings and notes)
+const validateUpdateApplicationReview = [
+  param('id').isMongoId().withMessage('Invalid application ID'),
+  body('reviewField')
+    .exists()
+    .withMessage('reviewField is required')
+    .bail()
+    .isIn(REVIEW_FIELD_OPTIONS)
+    .withMessage(`reviewField must be one of: ${REVIEW_FIELD_OPTIONS.join(', ')}`),
+  body('value').custom((value, { req }) => {
+    const { reviewField } = req.body;
+    const isNotesField = typeof reviewField === 'string' && reviewField.endsWith('Notes');
+
+    if (isNotesField) {
+      if (value !== undefined && value !== null && typeof value !== 'string') {
+        throw new Error('Notes value must be a string');
+      }
+      if (typeof value === 'string' && value.length > NOTES_MAX_LENGTH) {
+        throw new Error(`Notes must be ${NOTES_MAX_LENGTH} characters or fewer`);
+      }
+      return true;
+    }
+
+    if (value !== null && value !== undefined && !RATING_OPTIONS.includes(value)) {
+      throw new Error('Rating value must be "yes", "no", or null');
+    }
+    return true;
+  }),
+  handleValidationErrors,
+];
+
 // Validate get all applications query
 const validateGetApplications = [
   query('firstChoiceStatus')
@@ -307,6 +353,7 @@ module.exports = {
   validateCreateApplication,
   validateUpdateApplication,
   validateUpdateApplicationStatus,
+  validateUpdateApplicationReview,
   validateGetApplications,
   validateMongoId,
 };

--- a/app/api/v1/internship/models/Committee.js
+++ b/app/api/v1/internship/models/Committee.js
@@ -31,10 +31,6 @@ const CommitteeSchema = new Schema(
       type: String,
       required: false,
     },
-    subcommittees: {
-      type: [String],
-      default: [],
-    },
     isActive: {
       type: Boolean,
       default: true,

--- a/app/api/v1/internship/models/InternshipApplication.js
+++ b/app/api/v1/internship/models/InternshipApplication.js
@@ -170,7 +170,7 @@ const InternshipApplicationSchema = new Schema(
     },
     submittedAt: {
       type: Date,
-      default: Date.now,
+      default: null,
     },
     lastModifiedAt: {
       type: Date,

--- a/app/api/v1/internship/models/InternshipApplication.js
+++ b/app/api/v1/internship/models/InternshipApplication.js
@@ -145,6 +145,55 @@ const InternshipApplicationSchema = new Schema(
       default: 'pending',
     },
 
+    // Per-committee officer review: two independent yes/no ratings plus a
+    // shared notes field, filled in by whichever officers on that committee
+    // review the candidate.
+    firstChoiceOfficer1Rating: {
+      type: String,
+      enum: ['yes', 'no', 'maybe', null],
+      default: null,
+    },
+    firstChoiceOfficer2Rating: {
+      type: String,
+      enum: ['yes', 'no', 'maybe', null],
+      default: null,
+    },
+    firstChoiceNotes: {
+      type: String,
+      trim: true,
+      default: '',
+    },
+    secondChoiceOfficer1Rating: {
+      type: String,
+      enum: ['yes', 'no', 'maybe', null],
+      default: null,
+    },
+    secondChoiceOfficer2Rating: {
+      type: String,
+      enum: ['yes', 'no', 'maybe', null],
+      default: null,
+    },
+    secondChoiceNotes: {
+      type: String,
+      trim: true,
+      default: '',
+    },
+    thirdChoiceOfficer1Rating: {
+      type: String,
+      enum: ['yes', 'no', 'maybe', null],
+      default: null,
+    },
+    thirdChoiceOfficer2Rating: {
+      type: String,
+      enum: ['yes', 'no', 'maybe', null],
+      default: null,
+    },
+    thirdChoiceNotes: {
+      type: String,
+      trim: true,
+      default: '',
+    },
+
     // Metadata
     applicationCycle: {
       type: String,

--- a/app/api/v1/internship/models/InternshipApplication.js
+++ b/app/api/v1/internship/models/InternshipApplication.js
@@ -1,11 +1,20 @@
 const mongoose = require('mongoose');
 const { MIN_GRADUATION_YEAR } = require('../config/constants');
+const { computeDefaultCycleLabel, getCurrentCycle } = require('./InternshipSettings');
 
 const { Schema } = mongoose;
 
-function getCurrentApplicationCycle(referenceDate = new Date()) {
-  const year = referenceDate.getFullYear();
-  return `${year}-${year + 1}`;
+// Used only as the Mongoose schema default below (a synchronous fallback for
+// direct `new InternshipApplication()` construction outside request context,
+// e.g. tests/seed scripts). Real request flows call the async
+// getCurrentApplicationCycle() below instead, which reads the admin-settable
+// stored cycle.
+function getCurrentApplicationCycleDefault(referenceDate = new Date()) {
+  return computeDefaultCycleLabel(referenceDate);
+}
+
+async function getCurrentApplicationCycle() {
+  return getCurrentCycle();
 }
 
 const InternshipApplicationSchema = new Schema(
@@ -199,7 +208,7 @@ const InternshipApplicationSchema = new Schema(
       type: String,
       required: true,
       index: true,
-      default: getCurrentApplicationCycle,
+      default: getCurrentApplicationCycleDefault,
     },
     // Tracks member submission, not officer review
     submissionStatus: {
@@ -214,6 +223,19 @@ const InternshipApplicationSchema = new Schema(
       index: true,
     },
     deletedBy: {
+      type: String,
+      default: null,
+    },
+    // Set when an admin archives this application's cycle (either via a
+    // per-committee archive or a global "start new cycle" action). Distinct
+    // from deletedAt/deletedBy: archived applications persist and remain
+    // visible in past-cycle views, they're just excluded from current views.
+    archivedAt: {
+      type: Date,
+      default: null,
+      index: true,
+    },
+    archivedBy: {
       type: String,
       default: null,
     },

--- a/app/api/v1/internship/models/InternshipSettings.js
+++ b/app/api/v1/internship/models/InternshipSettings.js
@@ -1,0 +1,51 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+function computeDefaultCycleLabel(referenceDate = new Date()) {
+  const year = referenceDate.getFullYear();
+  return `${year}-${year + 1}`;
+}
+
+// Singleton collection: exactly one document tracks the admin-controlled
+// "current" application cycle. Applications stamp this value at creation
+// time so archiving/advancing the cycle can bulk-select "everything in the
+// outgoing cycle" without depending on wall-clock date math.
+const InternshipSettingsSchema = new Schema(
+  {
+    currentApplicationCycle: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+const InternshipSettings = mongoose.model('InternshipSettings', InternshipSettingsSchema);
+
+async function getCurrentCycle() {
+  const settings = await InternshipSettings.findOneAndUpdate(
+    {},
+    { $setOnInsert: { currentApplicationCycle: computeDefaultCycleLabel() } },
+    { new: true, upsert: true },
+  );
+  return settings.currentApplicationCycle;
+}
+
+async function setCurrentCycle(newCycle) {
+  const settings = await InternshipSettings.findOneAndUpdate(
+    {},
+    { $set: { currentApplicationCycle: newCycle } },
+    { new: true, upsert: true },
+  );
+  return settings.currentApplicationCycle;
+}
+
+module.exports = {
+  InternshipSettings,
+  computeDefaultCycleLabel,
+  getCurrentCycle,
+  setCurrentCycle,
+};

--- a/scripts/seed-internship-test-data.js
+++ b/scripts/seed-internship-test-data.js
@@ -1,0 +1,156 @@
+require('dotenv').config({ quiet: true });
+
+const mongoose = require('mongoose');
+
+const { db, User } = require('../app/db');
+const { Committee } = require('../app/api/v1/internship/models/Committee');
+const {
+  InternshipApplication,
+  getCurrentApplicationCycle,
+} = require('../app/api/v1/internship/models/InternshipApplication');
+
+const mongoHost = process.env.MONGO_HOST;
+const mongoPort = process.env.MONGO_PORT; 
+const mongoDatabase = process.env.MONGO_DATABASE;
+const mongoUser = process.env.MONGO_ROOT_USERNAME;
+const mongoPassword = process.env.MONGO_ROOT_PASSWORD;
+const mongoUri = process.env.MONGODB_URI
+  || `mongodb://${mongoUser}:${mongoPassword}@${mongoHost}:${mongoPort}/${mongoDatabase}?authSource=admin`;
+const seedEmail = process.env.SEED_EMAIL || process.env.SEED_USER_EMAIL || '';
+const seedUuid = process.env.SEED_USER_UUID || '';
+const applicationCycle = process.env.SEED_APPLICATION_CYCLE || getCurrentApplicationCycle();
+const applicationStatus = (process.env.SEED_STATUS).toLowerCase();
+const committeeNames = (process.env.SEED_COMMITTEES)
+  .split(',')
+  .map((name) => name.trim())
+  .filter(Boolean);
+
+function getCommitteeSeed(name, index) {
+  const normalized = name.trim();
+  const displayName = normalized.charAt(0).toUpperCase() + normalized.slice(1);
+
+  return {
+    update: {
+      name: displayName,
+      displayName,
+      subcommittees: [],
+      isActive: process.env.SEED_ACTIVE_COMMITTEES === 'false' ? index === 0 : true,
+      internLimit: Number(process.env.SEED_INTERN_LIMIT || 10),
+      applicationDeadline: new Date(process.env.SEED_APPLICATION_DEADLINE || '2030-10-15T23:59:59.000Z'),
+      customQuestions: [],
+      updatedAt: new Date(),
+    },
+    insert: {
+      description: `${displayName} committee used for internship testing.`,
+      createdAt: new Date(),
+    },
+  };
+}
+
+async function seedCommittee(seed) {
+  const committee = await Committee.findOneAndUpdate(
+    { name: seed.update.name },
+    {
+      $set: seed.update,
+      $setOnInsert: seed.insert,
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  );
+
+  return committee;
+}
+
+async function resolveSeedUser() {
+  if (seedUuid) {
+    const userByUuid = await User.findOne({ where: { uuid: seedUuid } });
+    if (userByUuid) return userByUuid;
+    throw new Error(`No Postgres user found for UUID ${seedUuid}.`);
+  }
+
+  if (seedEmail) {
+    const userByEmail = await User.findOne({ where: { email: seedEmail } });
+    if (userByEmail) return userByEmail;
+    throw new Error(`No Postgres user found for email ${seedEmail}.`);
+  }
+
+  throw new Error('Set SEED_EMAIL or SEED_USER_UUID to choose which Postgres user to seed for.');
+}
+
+async function main() {
+  try {
+    if (!['draft', 'submitted'].includes(applicationStatus)) {
+      throw new Error("SEED_STATUS must be either 'draft' or 'submitted'.");
+    }
+
+    await db.authenticate();
+    await mongoose.connect(mongoUri);
+
+    const user = await resolveSeedUser();
+
+    if (committeeNames.length < 1) {
+      throw new Error('SEED_COMMITTEES must contain at least one committee name.');
+    }
+
+    const committees = await Promise.all(
+      committeeNames.map((name, index) => seedCommittee(getCommitteeSeed(name, index))),
+    );
+
+    await InternshipApplication.deleteOne({
+      userId: user.uuid,
+      applicationCycle,
+    });
+
+    const firstChoiceCommittee = committees[0]?._id;
+    const secondChoiceCommittee = committees[1]?._id || undefined;
+    const thirdChoiceCommittee = committees[2]?._id || undefined;
+
+    const baseApplication = {
+      userId: user.uuid,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      email: user.email,
+      university: 'UCLA',
+      major: user.major,
+      graduationYear: Number(process.env.SEED_GRADUATION_YEAR || 2027),
+      firstChoiceCommittee,
+      secondChoiceCommittee,
+      thirdChoiceCommittee,
+      firstChoiceResponses: [],
+      secondChoiceResponses: [],
+      thirdChoiceResponses: [],
+      firstChoiceStatus: process.env.SEED_FIRST_STATUS || 'reviewing',
+      secondChoiceStatus: process.env.SEED_SECOND_STATUS || 'pending',
+      thirdChoiceStatus: process.env.SEED_THIRD_STATUS || 'interview_scheduled',
+      applicationCycle,
+      submissionStatus: applicationStatus,
+      deletedAt: null,
+      deletedBy: null,
+      lastModifiedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    if (applicationStatus === 'submitted') {
+      baseApplication.submittedAt = new Date();
+    } else {
+      baseApplication.submittedAt = null;
+    }
+
+    const application = await InternshipApplication.create(baseApplication);
+
+    console.log(`Seeded internship test data for ${user.email} (${user.uuid})`);
+    console.log(`- application cycle: ${applicationCycle}`);
+    console.log(`- application status: ${applicationStatus}`);
+    console.log(`- committees: ${committees.map((committee) => committee.displayName).join(', ')}`);
+    console.log(`- application id: ${application._id}`);
+  } finally {
+    await mongoose.disconnect().catch(() => {});
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('Seed failed:', error.message);
+    process.exit(1);
+  });

--- a/scripts/seed-internship-test-data.js
+++ b/scripts/seed-internship-test-data.js
@@ -18,7 +18,6 @@ const mongoUri = process.env.MONGODB_URI
   || `mongodb://${mongoUser}:${mongoPassword}@${mongoHost}:${mongoPort}/${mongoDatabase}?authSource=admin`;
 const seedEmail = process.env.SEED_EMAIL || process.env.SEED_USER_EMAIL || '';
 const seedUuid = process.env.SEED_USER_UUID || '';
-const applicationCycle = process.env.SEED_APPLICATION_CYCLE || getCurrentApplicationCycle();
 const applicationStatus = (process.env.SEED_STATUS || 'draft').toLowerCase();
 const defaultCommitteeNames = 'Hack,AI,Design,Cyber,ICPC,Studio,TeachLA,W,Cloud';
 const committeeNames = (process.env.SEED_COMMITTEES || defaultCommitteeNames)
@@ -323,7 +322,6 @@ function getCommitteeSeed(name, index) {
     update: {
       name: displayName,
       displayName,
-      subcommittees: [],
       isActive: shouldCommitteeBeActive(index),
       internLimit: Number(process.env.SEED_INTERN_LIMIT || 10),
       applicationDeadline: new Date(process.env.SEED_APPLICATION_DEADLINE || '2030-10-15T23:59:59.000Z'),
@@ -393,6 +391,9 @@ async function main() {
 
     await db.authenticate();
     await mongoose.connect(mongoUri);
+
+    const applicationCycle = process.env.SEED_APPLICATION_CYCLE
+      || await getCurrentApplicationCycle();
 
     const user = await resolveSeedUser();
 

--- a/scripts/seed-internship-test-data.js
+++ b/scripts/seed-internship-test-data.js
@@ -10,7 +10,7 @@ const {
 } = require('../app/api/v1/internship/models/InternshipApplication');
 
 const mongoHost = process.env.MONGO_HOST;
-const mongoPort = process.env.MONGO_PORT; 
+const mongoPort = process.env.MONGO_PORT;
 const mongoDatabase = process.env.MONGO_DATABASE;
 const mongoUser = process.env.MONGO_ROOT_USERNAME;
 const mongoPassword = process.env.MONGO_ROOT_PASSWORD;
@@ -20,10 +20,13 @@ const seedEmail = process.env.SEED_EMAIL || process.env.SEED_USER_EMAIL || '';
 const seedUuid = process.env.SEED_USER_UUID || '';
 const applicationCycle = process.env.SEED_APPLICATION_CYCLE || getCurrentApplicationCycle();
 const applicationStatus = (process.env.SEED_STATUS || 'draft').toLowerCase();
-const committeeNames = (process.env.SEED_COMMITTEES || 'Hack,AI,Design')
+const defaultCommitteeNames = 'Hack,AI,Design,Cyber,ICPC,Studio,TeachLA,W,Cloud';
+const committeeNames = (process.env.SEED_COMMITTEES || defaultCommitteeNames)
   .split(',')
   .map((name) => name.trim())
   .filter(Boolean);
+const shouldSeedApplication = process.env.SEED_APPLICATION === 'true'
+  || process.env.SEED_CREATE_APPLICATION === 'true';
 
 const QUESTION_SETS_BY_SLUG = {
   ai: [
@@ -308,6 +311,10 @@ function getCustomQuestions(name) {
   ];
 }
 
+function shouldCommitteeBeActive(index) {
+  return process.env.SEED_ACTIVE_COMMITTEES === 'false' ? index === 0 : true;
+}
+
 function getCommitteeSeed(name, index) {
   const normalized = name.trim();
   const displayName = normalized.charAt(0).toUpperCase() + normalized.slice(1);
@@ -317,7 +324,7 @@ function getCommitteeSeed(name, index) {
       name: displayName,
       displayName,
       subcommittees: [],
-      isActive: process.env.SEED_ACTIVE_COMMITTEES === 'false' ? index === 0 : true,
+      isActive: shouldCommitteeBeActive(index),
       internLimit: Number(process.env.SEED_INTERN_LIMIT || 10),
       applicationDeadline: new Date(process.env.SEED_APPLICATION_DEADLINE || '2030-10-15T23:59:59.000Z'),
       customQuestions: getCustomQuestions(displayName),
@@ -341,6 +348,25 @@ async function seedCommittee(seed) {
   );
 
   return committee;
+}
+
+async function refreshExistingCommittees() {
+  const existingCommittees = await Committee.find({});
+
+  await Promise.all(existingCommittees.map((committee, index) => (
+    Committee.findByIdAndUpdate(
+      committee.id,
+      {
+        $set: {
+          isActive: shouldCommitteeBeActive(index),
+          customQuestions: getCustomQuestions(committee.displayName || committee.name),
+          applicationDeadline: new Date(process.env.SEED_APPLICATION_DEADLINE || '2030-10-15T23:59:59.000Z'),
+          updatedAt: new Date(),
+        },
+      },
+      { new: true, runValidators: true },
+    )
+  )));
 }
 
 async function resolveSeedUser() {
@@ -377,15 +403,24 @@ async function main() {
     const committees = await Promise.all(
       committeeNames.map((name, index) => seedCommittee(getCommitteeSeed(name, index))),
     );
+    await refreshExistingCommittees();
 
     await InternshipApplication.deleteOne({
       userId: user.uuid,
       applicationCycle,
     });
 
-    const firstChoiceCommittee = committees[0]?._id;
-    const secondChoiceCommittee = committees[1]?._id || undefined;
-    const thirdChoiceCommittee = committees[2]?._id || undefined;
+    if (!shouldSeedApplication) {
+      console.log(`Seeded internship committees for ${user.email} (${user.uuid})`);
+      console.log(`- application cycle: ${applicationCycle}`);
+      console.log(`- committees: ${committees.map((committee) => committee.displayName).join(', ')}`);
+      console.log('- application: none (frontend will create and save selections)');
+      return;
+    }
+
+    const firstChoiceCommittee = committees[0] && committees[0].id;
+    const secondChoiceCommittee = (committees[1] && committees[1].id) || undefined;
+    const thirdChoiceCommittee = (committees[2] && committees[2].id) || undefined;
 
     const baseApplication = {
       userId: user.uuid,
@@ -425,7 +460,7 @@ async function main() {
     console.log(`- application cycle: ${applicationCycle}`);
     console.log(`- application status: ${applicationStatus}`);
     console.log(`- committees: ${committees.map((committee) => committee.displayName).join(', ')}`);
-    console.log(`- application id: ${application._id}`);
+    console.log(`- application id: ${application.id}`);
   } finally {
     await mongoose.disconnect().catch(() => {});
   }

--- a/scripts/seed-internship-test-data.js
+++ b/scripts/seed-internship-test-data.js
@@ -19,11 +19,294 @@ const mongoUri = process.env.MONGODB_URI
 const seedEmail = process.env.SEED_EMAIL || process.env.SEED_USER_EMAIL || '';
 const seedUuid = process.env.SEED_USER_UUID || '';
 const applicationCycle = process.env.SEED_APPLICATION_CYCLE || getCurrentApplicationCycle();
-const applicationStatus = (process.env.SEED_STATUS).toLowerCase();
-const committeeNames = (process.env.SEED_COMMITTEES)
+const applicationStatus = (process.env.SEED_STATUS || 'draft').toLowerCase();
+const committeeNames = (process.env.SEED_COMMITTEES || 'Hack,AI,Design')
   .split(',')
   .map((name) => name.trim())
   .filter(Boolean);
+
+const QUESTION_SETS_BY_SLUG = {
+  ai: [
+    {
+      questionKey: 'ai_interest',
+      questionText: 'What area of AI or machine learning are you most excited to explore with ACM AI?',
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: 'ai_experience',
+      questionText: 'Tell us about a project, class, paper, or idea that shaped your interest in AI.',
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: 'ai_track',
+      questionText: 'Which ACM AI track sounds most interesting to you?',
+      questionType: 'multiple_choice',
+      choices: ['Research', 'Projects', 'Education', 'Outreach', 'Still exploring'],
+      required: true,
+      order: 3,
+    },
+  ],
+  cyber: [
+    {
+      questionKey: 'cyber_interest',
+      questionText: 'What part of cybersecurity are you most interested in learning more about?',
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: 'cyber_learning_style',
+      questionText: 'Describe how you approach learning a new technical topic or solving an unfamiliar challenge.',
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: 'cyber_focus',
+      questionText: 'Which Cyber activity would you be most excited to help with?',
+      questionType: 'multiple_choice',
+      choices: ['Workshops', 'CTFs', 'Security projects', 'Community events', 'Still exploring'],
+      required: true,
+      order: 3,
+    },
+  ],
+  design: [
+    {
+      questionKey: 'design_interest',
+      questionText: 'Why are you interested in ACM Design?',
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: 'design_process',
+      questionText: 'Describe a design, creative, or user experience problem you enjoyed thinking through.',
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: 'design_role',
+      questionText: 'Which type of Design work would you like to grow in?',
+      questionType: 'multiple_choice',
+      choices: ['Product design', 'Visual design', 'Design systems', 'Research', 'Still exploring'],
+      required: true,
+      order: 3,
+    },
+  ],
+  hack: [
+    {
+      questionKey: 'hack_interest',
+      questionText: 'What draws you to ACM Hack and building with others?',
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: 'hack_build',
+      questionText: 'Tell us about something you have built or want to build.',
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: 'hack_event',
+      questionText: 'Which kind of Hack event would you be most excited to support?',
+      questionType: 'multiple_choice',
+      choices: ['Beginner workshops', 'Hack nights', 'Project showcases', 'Mentorship', 'Still exploring'],
+      required: true,
+      order: 3,
+    },
+  ],
+  icpc: [
+    {
+      questionKey: 'icpc_interest',
+      questionText: 'Why are you interested in ACM ICPC?',
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: 'icpc_problem_solving',
+      questionText: 'Describe a problem-solving experience you enjoyed, technical or non-technical.',
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: 'icpc_focus',
+      questionText: 'Which ICPC area would you most like to participate in?',
+      questionType: 'multiple_choice',
+      choices: ['Competitive programming', 'Interview prep', 'Teaching algorithms', 'Community practice', 'Still exploring'],
+      required: true,
+      order: 3,
+    },
+  ],
+  studio: [
+    {
+      questionKey: 'studio_interest',
+      questionText: 'What interests you about games, interactive media, or ACM Studio?',
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: 'studio_creative_work',
+      questionText: 'Tell us about a game, story, tool, artwork, or interactive experience that inspires you.',
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: 'studio_role',
+      questionText: 'Which Studio role would you most like to try?',
+      questionType: 'multiple_choice',
+      choices: ['Programming', 'Game design', 'Art', 'Audio', 'Production', 'Still exploring'],
+      required: true,
+      order: 3,
+    },
+  ],
+  teachla: [
+    {
+      questionKey: 'teachla_interest',
+      questionText: 'Why are you interested in teaching computer science with Teach LA?',
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: 'teachla_teaching',
+      questionText: 'Describe a time you helped someone learn something new.',
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: 'teachla_focus',
+      questionText: 'Which Teach LA workstream sounds most interesting?',
+      questionType: 'multiple_choice',
+      choices: ['Curriculum', 'Classroom teaching', 'Developer tools', 'Outreach', 'Still exploring'],
+      required: true,
+      order: 3,
+    },
+  ],
+  w: [
+    {
+      questionKey: 'w_interest',
+      questionText: 'Why are you interested in ACM W?',
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: 'w_community',
+      questionText: 'How would you like to help build community for women and gender minorities in tech?',
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: 'w_programming',
+      questionText: 'Which ACM W programming area are you most excited about?',
+      questionType: 'multiple_choice',
+      choices: ['Mentorship', 'Social events', 'Technical workshops', 'Industry events', 'Still exploring'],
+      required: true,
+      order: 3,
+    },
+  ],
+  acmw: [
+    {
+      questionKey: 'w_interest',
+      questionText: 'Why are you interested in ACM W?',
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: 'w_community',
+      questionText: 'How would you like to help build community for women and gender minorities in tech?',
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: 'w_programming',
+      questionText: 'Which ACM W programming area are you most excited about?',
+      questionType: 'multiple_choice',
+      choices: ['Mentorship', 'Social events', 'Technical workshops', 'Industry events', 'Still exploring'],
+      required: true,
+      order: 3,
+    },
+  ],
+  cloud: [
+    {
+      questionKey: 'cloud_interest',
+      questionText: 'What interests you about cloud computing, infrastructure, or developer tools?',
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: 'cloud_project',
+      questionText: 'Describe a technical system or product you would like to understand better.',
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: 'cloud_focus',
+      questionText: 'Which Cloud topic sounds most interesting?',
+      questionType: 'multiple_choice',
+      choices: ['Web services', 'Infrastructure', 'DevOps', 'Databases', 'Still exploring'],
+      required: true,
+      order: 3,
+    },
+  ],
+};
+
+function slugifyCommitteeName(name) {
+  return name
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+function getCustomQuestions(name) {
+  const slug = slugifyCommitteeName(name) || 'committee';
+  const knownQuestions = QUESTION_SETS_BY_SLUG[slug];
+
+  if (knownQuestions) {
+    return knownQuestions;
+  }
+
+  return [
+    {
+      questionKey: `${slug}_interest`,
+      questionText: `Why are you interested in ${name}?`,
+      questionType: 'long_text',
+      required: true,
+      order: 1,
+    },
+    {
+      questionKey: `${slug}_experience`,
+      questionText: `Tell us about an experience, project, or goal that connects to ${name}.`,
+      questionType: 'long_text',
+      required: true,
+      order: 2,
+    },
+    {
+      questionKey: `${slug}_contribution`,
+      questionText: `How would you like to contribute to ${name} as an intern?`,
+      questionType: 'long_text',
+      required: true,
+      order: 3,
+    },
+  ];
+}
 
 function getCommitteeSeed(name, index) {
   const normalized = name.trim();
@@ -37,7 +320,7 @@ function getCommitteeSeed(name, index) {
       isActive: process.env.SEED_ACTIVE_COMMITTEES === 'false' ? index === 0 : true,
       internLimit: Number(process.env.SEED_INTERN_LIMIT || 10),
       applicationDeadline: new Date(process.env.SEED_APPLICATION_DEADLINE || '2030-10-15T23:59:59.000Z'),
-      customQuestions: [],
+      customQuestions: getCustomQuestions(displayName),
       updatedAt: new Date(),
     },
     insert: {

--- a/scripts/seed-officer-test-applications.js
+++ b/scripts/seed-officer-test-applications.js
@@ -17,7 +17,7 @@ const mongoUri = process.env.MONGODB_URI
   || `mongodb://${mongoUser}:${mongoPassword}@${mongoHost}:${mongoPort}/${mongoDatabase}?authSource=admin`;
 
 const targetCommitteeName = process.argv[2] || process.env.SEED_OFFICER_COMMITTEE || 'ICPC';
-const applicationCycle = process.env.SEED_APPLICATION_CYCLE || getCurrentApplicationCycle();
+let applicationCycle;
 
 const STATUS_OPTIONS = ['pending', 'reviewing', 'interview_scheduled', 'accepted', 'rejected'];
 const MAJORS = ['Computer Science', 'Computer Science and Engineering', 'Electrical Engineering', 'Statistics and Data Science', 'Mathematics', 'Cognitive Science'];
@@ -135,6 +135,8 @@ function buildApplicant(index, targetCommittee, otherCommittees) {
 
 async function main() {
   await mongoose.connect(mongoUri);
+
+  applicationCycle = process.env.SEED_APPLICATION_CYCLE || await getCurrentApplicationCycle();
 
   const targetCommittee = await Committee.findOne({
     $or: [{ name: targetCommitteeName }, { displayName: targetCommitteeName }],

--- a/scripts/seed-officer-test-applications.js
+++ b/scripts/seed-officer-test-applications.js
@@ -1,0 +1,187 @@
+require('dotenv').config({ quiet: true });
+
+const mongoose = require('mongoose');
+
+const { Committee } = require('../app/api/v1/internship/models/Committee');
+const {
+  InternshipApplication,
+  getCurrentApplicationCycle,
+} = require('../app/api/v1/internship/models/InternshipApplication');
+
+const mongoHost = process.env.MONGO_HOST;
+const mongoPort = process.env.MONGO_PORT;
+const mongoDatabase = process.env.MONGO_DATABASE;
+const mongoUser = process.env.MONGO_ROOT_USERNAME;
+const mongoPassword = process.env.MONGO_ROOT_PASSWORD;
+const mongoUri = process.env.MONGODB_URI
+  || `mongodb://${mongoUser}:${mongoPassword}@${mongoHost}:${mongoPort}/${mongoDatabase}?authSource=admin`;
+
+const targetCommitteeName = process.argv[2] || process.env.SEED_OFFICER_COMMITTEE || 'ICPC';
+const applicationCycle = process.env.SEED_APPLICATION_CYCLE || getCurrentApplicationCycle();
+
+const STATUS_OPTIONS = ['pending', 'reviewing', 'interview_scheduled', 'accepted', 'rejected'];
+const MAJORS = ['Computer Science', 'Computer Science and Engineering', 'Electrical Engineering', 'Statistics and Data Science', 'Mathematics', 'Cognitive Science'];
+const FIRST_NAMES = ['Ava', 'Noah', 'Mia', 'Liam', 'Zoe', 'Ethan', 'Priya', 'Kai', 'Luna', 'Omar', 'Sofia', 'Jax', 'Nina', 'Theo', 'Ruby'];
+const LAST_NAMES = ['Nguyen', 'Patel', 'Kim', 'Garcia', 'Chen', 'Okafor', 'Rossi', 'Park', 'Ivanov', 'Silva', 'Haddad', 'Tanaka', 'Fischer', 'Reyes', 'Novak'];
+
+const APPLICANT_COUNT = 15;
+
+function pick(arr, index) {
+  return arr[index % arr.length];
+}
+
+// Build a real response for each of a committee's actual custom questions, so
+// the officer dashboard's answer drawer and the backend's per-committee
+// scrubbing both have real content to show/hide instead of empty arrays.
+function buildResponses(committee, index) {
+  if (!committee || !Array.isArray(committee.customQuestions)) return [];
+
+  return committee.customQuestions.map((question, qIndex) => {
+    let answer;
+    if (question.questionType === 'multiple_choice' && Array.isArray(question.choices) && question.choices.length > 0) {
+      answer = pick(question.choices, index + qIndex);
+    } else {
+      answer = `Applicant ${index} response to "${question.questionText}" — sample answer for testing purposes.`;
+    }
+    return { questionKey: question.questionKey, question: question.questionText, answer };
+  });
+}
+
+const LONG_NOTE = 'Candidate showed strong problem-solving skills during the technical portion of the '
+  + 'interview, communicated their thought process clearly, and asked thoughtful clarifying '
+  + 'questions. Slightly less confident when discussing team collaboration experience, but '
+  + 'overall a promising applicant who would likely ramp up quickly.';
+
+// Vary officer ratings/notes so the dashboard has a mix of unrated, partially
+// rated, and fully rated rows (including a "maybe") — including one
+// long-note case to exercise the notes column's read-more/truncation
+// behavior.
+function buildReviewFields(index) {
+  const variant = index % 5;
+  if (variant === 1) return { officer1Rating: 'yes', officer2Rating: null, notes: 'Solid answers, worth a follow-up.' };
+  if (variant === 2) return { officer1Rating: 'yes', officer2Rating: 'yes', notes: LONG_NOTE };
+  if (variant === 3) return { officer1Rating: 'no', officer2Rating: 'no', notes: '' };
+  if (variant === 4) return { officer1Rating: 'maybe', officer2Rating: 'yes', notes: 'Undecided — want to compare against the rest of the pool first.' };
+  return { officer1Rating: null, officer2Rating: null, notes: '' };
+}
+
+function buildApplicant(index, targetCommittee, otherCommittees) {
+  const firstName = pick(FIRST_NAMES, index);
+  const lastName = pick(LAST_NAMES, index);
+  const status = pick(STATUS_OPTIONS, index);
+  // Spread the target committee across 1st/2nd/3rd choice so the officer
+  // dashboard's choice-rank filter has data to filter against.
+  const rank = (index % 3) + 1;
+
+  const choiceCommittees = [null, null, null];
+  choiceCommittees[rank - 1] = targetCommittee;
+
+  const remainingSlots = [0, 1, 2].filter((slot) => slot !== rank - 1);
+  remainingSlots.forEach((slot, i) => {
+    if (otherCommittees[i]) {
+      choiceCommittees[slot] = otherCommittees[i];
+    }
+  });
+
+  const choiceStatuses = ['pending', 'pending', 'pending'];
+  choiceStatuses[rank - 1] = status;
+
+  const choiceResponses = choiceCommittees.map((committee) => buildResponses(committee, index));
+
+  // Officer review fields only make sense on the target committee's own
+  // slot — that's the only slot this seed run's officer would be reviewing.
+  const officer1Ratings = [null, null, null];
+  const officer2Ratings = [null, null, null];
+  const notes = ['', '', ''];
+  const reviewFields = buildReviewFields(index);
+  officer1Ratings[rank - 1] = reviewFields.officer1Rating;
+  officer2Ratings[rank - 1] = reviewFields.officer2Rating;
+  notes[rank - 1] = reviewFields.notes;
+
+  return {
+    userId: `officer-test-applicant-${index}`,
+    firstName,
+    lastName,
+    email: `officer.test.applicant${index}@g.ucla.edu`,
+    university: 'UCLA',
+    major: pick(MAJORS, index),
+    graduationYear: 2026 + (index % 4),
+    resumeUrl: `https://example.com/resumes/officer-test-applicant-${index}.pdf`,
+    coverLetter: `This is a placeholder cover letter for test applicant ${index}, generated by the officer test-data seed script.`,
+    firstChoiceCommittee: (choiceCommittees[0] && choiceCommittees[0].id) || undefined,
+    secondChoiceCommittee: (choiceCommittees[1] && choiceCommittees[1].id) || undefined,
+    thirdChoiceCommittee: (choiceCommittees[2] && choiceCommittees[2].id) || undefined,
+    firstChoiceResponses: choiceResponses[0],
+    secondChoiceResponses: choiceResponses[1],
+    thirdChoiceResponses: choiceResponses[2],
+    firstChoiceStatus: choiceStatuses[0],
+    secondChoiceStatus: choiceStatuses[1],
+    thirdChoiceStatus: choiceStatuses[2],
+    firstChoiceOfficer1Rating: officer1Ratings[0],
+    secondChoiceOfficer1Rating: officer1Ratings[1],
+    thirdChoiceOfficer1Rating: officer1Ratings[2],
+    firstChoiceOfficer2Rating: officer2Ratings[0],
+    secondChoiceOfficer2Rating: officer2Ratings[1],
+    thirdChoiceOfficer2Rating: officer2Ratings[2],
+    firstChoiceNotes: notes[0],
+    secondChoiceNotes: notes[1],
+    thirdChoiceNotes: notes[2],
+    applicationCycle,
+    submissionStatus: 'submitted',
+    submittedAt: new Date(),
+    lastModifiedAt: new Date(),
+  };
+}
+
+async function main() {
+  await mongoose.connect(mongoUri);
+
+  const targetCommittee = await Committee.findOne({
+    $or: [{ name: targetCommitteeName }, { displayName: targetCommitteeName }],
+  });
+
+  if (!targetCommittee) {
+    throw new Error(
+      `Committee "${targetCommitteeName}" not found. Run "make seed-internship-test-data" first, `
+      + 'or pass an existing committee name as the first argument.',
+    );
+  }
+
+  const otherCommittees = await Committee.find({ _id: { $ne: targetCommittee.id } }).limit(2);
+
+  await InternshipApplication.deleteMany({ userId: /^officer-test-applicant-/ });
+
+  const applicants = Array.from({ length: APPLICANT_COUNT }, (_, index) => (
+    buildApplicant(index, targetCommittee, otherCommittees)
+  ));
+
+  const created = await InternshipApplication.insertMany(applicants);
+
+  const byStatus = STATUS_OPTIONS.reduce((acc, status) => ({ ...acc, [status]: 0 }), {});
+  const byRank = { 1: 0, 2: 0, 3: 0 };
+  created.forEach((application) => {
+    const choices = [
+      [application.firstChoiceCommittee, application.firstChoiceStatus],
+      [application.secondChoiceCommittee, application.secondChoiceStatus],
+      [application.thirdChoiceCommittee, application.thirdChoiceStatus],
+    ];
+    choices.forEach(([committeeId, status], slot) => {
+      if (committeeId && committeeId.toString() === targetCommittee.id.toString()) {
+        byStatus[status] += 1;
+        byRank[slot + 1] += 1;
+      }
+    });
+  });
+
+  console.log(`Seeded ${created.length} submitted test applications for ${targetCommittee.displayName}`);
+  console.log(`- application cycle: ${applicationCycle}`);
+  console.log(`- by status: ${JSON.stringify(byStatus)}`);
+  console.log(`- by choice rank: ${JSON.stringify(byRank)}`);
+}
+
+main()
+  .then(() => mongoose.disconnect())
+  .catch((error) => {
+    console.error('Seed failed:', error.message);
+    process.exit(1);
+  });

--- a/tests/committee-archive-cycle.test.js
+++ b/tests/committee-archive-cycle.test.js
@@ -1,0 +1,447 @@
+jest.mock('google-auth-library', () => ({
+  OAuth2Client: jest.fn().mockImplementation(() => ({
+    verifyIdToken: jest.fn(),
+  })),
+}), { virtual: true });
+
+jest.mock('../app/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  log: jest.fn(),
+}));
+
+jest.mock('../app/api/v1/internship/models/Committee', () => ({
+  Committee: {
+    findById: jest.fn(),
+    find: jest.fn(),
+  },
+}));
+
+jest.mock('../app/api/v1/internship/models/InternshipApplication', () => ({
+  InternshipApplication: {
+    updateMany: jest.fn(),
+    distinct: jest.fn(),
+    find: jest.fn(),
+    countDocuments: jest.fn(),
+    aggregate: jest.fn(),
+  },
+  getCurrentApplicationCycle: jest.fn(),
+}));
+
+jest.mock('../app/api/v1/internship/models/InternshipSettings', () => ({
+  computeDefaultCycleLabel: jest.fn(() => '2099-2100'),
+  getCurrentCycle: jest.fn(),
+  setCurrentCycle: jest.fn(),
+}));
+
+const { Committee } = require('../app/api/v1/internship/models/Committee');
+const { InternshipApplication } = require('../app/api/v1/internship/models/InternshipApplication');
+const { getCurrentCycle, setCurrentCycle } = require('../app/api/v1/internship/models/InternshipSettings');
+const { archiveCommittee } = require('../app/api/v1/internship/controllers/committeeController');
+const { getCycleInfo, advanceCycle } = require('../app/api/v1/internship/controllers/cycleController');
+const { getAllApplications, getApplicationStatusCounts } = require('../app/api/v1/internship/controllers/applicationController');
+const error = require('../app/error');
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const adminUser = {
+  uuid: 'admin-uuid',
+  isAdmin: () => true,
+  isOfficer: () => false,
+  hasCommittee: () => false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('archiveCommittee', () => {
+  test('returns 404 when the committee does not exist', async () => {
+    Committee.findById.mockResolvedValue(null);
+
+    const req = { params: { id: 'missing' }, user: adminUser };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await archiveCommittee(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Committee not found' });
+    expect(InternshipApplication.updateMany).not.toHaveBeenCalled();
+  });
+
+  test('archives only the current cycle\'s applications for this committee, leaving the committee doc untouched', async () => {
+    const committeeDoc = { _id: 'c1' };
+    Committee.findById.mockResolvedValue(committeeDoc);
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    InternshipApplication.updateMany.mockResolvedValue({ modifiedCount: 7 });
+
+    const req = { params: { id: 'c1' }, user: adminUser };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await archiveCommittee(req, res, next);
+
+    expect(InternshipApplication.updateMany).toHaveBeenCalledWith(
+      {
+        $or: [
+          { firstChoiceCommittee: 'c1' },
+          { secondChoiceCommittee: 'c1' },
+          { thirdChoiceCommittee: 'c1' },
+        ],
+        applicationCycle: '2026-2027',
+        deletedAt: null,
+        archivedAt: null,
+      },
+      { $set: { archivedAt: expect.any(Date), archivedBy: 'admin-uuid' } },
+    );
+    expect(res.json).toHaveBeenCalledWith({ error: null, archivedCount: 7 });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('forwards errors to next()', async () => {
+    Committee.findById.mockRejectedValue(new Error('mongo down'));
+    const next = jest.fn();
+
+    await archiveCommittee({ params: { id: 'c1' }, user: adminUser }, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+
+describe('getCycleInfo', () => {
+  test('returns current cycle, past cycles (excluding current), and a suggested next cycle', async () => {
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    InternshipApplication.distinct.mockResolvedValue(['2024-2025', '2025-2026']);
+
+    const res = mockRes();
+    await getCycleInfo({ user: adminUser }, res, jest.fn());
+
+    expect(InternshipApplication.distinct).toHaveBeenCalledWith('applicationCycle', {
+      applicationCycle: { $ne: '2026-2027' },
+    });
+    expect(res.json).toHaveBeenCalledWith({
+      error: null,
+      currentCycle: '2026-2027',
+      suggestedNextCycle: '2027-2028',
+      pastCycles: ['2024-2025', '2025-2026'],
+    });
+  });
+
+  test('falls back to computeDefaultCycleLabel when the current cycle is a non-standard custom label', async () => {
+    getCurrentCycle.mockResolvedValue('Custom Cycle Label');
+    InternshipApplication.distinct.mockResolvedValue([]);
+
+    const res = mockRes();
+    await getCycleInfo({ user: adminUser }, res, jest.fn());
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.suggestedNextCycle).toBe('2099-2100');
+  });
+});
+
+describe('advanceCycle', () => {
+  test('archives the outgoing cycle\'s applications and stores the new current cycle', async () => {
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    InternshipApplication.updateMany.mockResolvedValue({ modifiedCount: 42 });
+
+    const req = { user: adminUser, body: { newCycle: '2027-2028' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await advanceCycle(req, res, next);
+
+    expect(InternshipApplication.updateMany).toHaveBeenCalledWith(
+      { applicationCycle: '2026-2027', deletedAt: null, archivedAt: null },
+      { $set: { archivedAt: expect.any(Date), archivedBy: 'admin-uuid' } },
+    );
+    expect(setCurrentCycle).toHaveBeenCalledWith('2027-2028');
+    expect(res.json).toHaveBeenCalledWith({
+      error: null,
+      previousCycle: '2026-2027',
+      newCycle: '2027-2028',
+      archivedCount: 42,
+    });
+  });
+
+  test('defaults to the suggested next cycle when newCycle is omitted from the body', async () => {
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    InternshipApplication.updateMany.mockResolvedValue({ modifiedCount: 0 });
+
+    const req = { user: adminUser, body: {} };
+    const res = mockRes();
+
+    await advanceCycle(req, res, jest.fn());
+
+    expect(setCurrentCycle).toHaveBeenCalledWith('2027-2028');
+  });
+
+  test('rejects when newCycle equals the current cycle', async () => {
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    const next = jest.fn();
+
+    await advanceCycle({ user: adminUser, body: { newCycle: '2026-2027' } }, mockRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const passed = next.mock.calls[0][0];
+    expect(passed).toBeInstanceOf(error.BadRequest);
+    expect(InternshipApplication.updateMany).not.toHaveBeenCalled();
+    expect(setCurrentCycle).not.toHaveBeenCalled();
+  });
+
+  test('rejects a blank newCycle', async () => {
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    const next = jest.fn();
+
+    await advanceCycle({ user: adminUser, body: { newCycle: '   ' } }, mockRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(error.BadRequest);
+  });
+});
+
+describe('getAllApplications — search and archived query params', () => {
+  const setupFind = () => {
+    InternshipApplication.find.mockReturnValue({
+      sort: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([]),
+    });
+    InternshipApplication.countDocuments.mockResolvedValue(0);
+  };
+
+  test('defaults to excluding archived applications (archivedAt: null)', async () => {
+    setupFind();
+    const req = { user: adminUser, query: {} };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.archivedAt).toBeNull();
+  });
+
+  test('archived=true returns only archived applications', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { archived: true } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.archivedAt).toEqual({ $ne: null });
+  });
+
+  test('search builds a case-insensitive $or across firstName/lastName/email', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { search: 'ada' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toHaveLength(3);
+    expect(query.$or[0].firstName).toBeInstanceOf(RegExp);
+    expect(query.$or[0].firstName.flags).toContain('i');
+    expect(query.$or[0].firstName.test('Ada Lovelace')).toBe(true);
+  });
+
+  test('search input is regex-escaped so special characters cannot break the query', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { search: 'a.b+c' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    const emailRegex = query.$or[2].email;
+    expect(emailRegex.test('a.b+c@example.com')).toBe(true);
+    expect(emailRegex.test('axbxc@example.com')).toBe(false);
+  });
+
+  test('officer committee-scope and search combine via $and instead of clobbering each other', async () => {
+    setupFind();
+    Committee.find.mockReturnValue({
+      select: jest.fn().mockResolvedValue([
+        { id: 'committee-1', name: 'Hack', displayName: 'Hack' },
+      ]),
+    });
+    const officerUser = {
+      uuid: 'officer-uuid',
+      isAdmin: () => false,
+      isOfficer: () => true,
+      committees: ['Hack'],
+    };
+    const req = { user: officerUser, query: { search: 'ada' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toBeUndefined();
+    expect(query.$and).toHaveLength(2);
+    expect(query.$and[0].$or[0]).toHaveProperty('firstChoiceCommittee');
+    expect(query.$and[1].$or[0]).toHaveProperty('firstName');
+  });
+
+  test('committeeId matches any of the 3 choice slots, not just the first', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { committeeId: 'c1' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toEqual([
+      { firstChoiceCommittee: 'c1' },
+      { secondChoiceCommittee: 'c1' },
+      { thirdChoiceCommittee: 'c1' },
+    ]);
+  });
+
+  test('status matches any of the 3 choice slots, not just the first', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { status: 'reviewing' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toEqual([
+      { firstChoiceStatus: 'reviewing' },
+      { secondChoiceStatus: 'reviewing' },
+      { thirdChoiceStatus: 'reviewing' },
+    ]);
+  });
+
+  test('committeeId and status are paired per-slot, not independently — a different slot with the same status must not match', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { committeeId: 'c1', status: 'reviewing' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    // Combined into one $or (not two separate $and members), so each clause
+    // requires committee AND status on the SAME slot.
+    expect(query.$or).toEqual([
+      { firstChoiceCommittee: 'c1', firstChoiceStatus: 'reviewing' },
+      { secondChoiceCommittee: 'c1', secondChoiceStatus: 'reviewing' },
+      { thirdChoiceCommittee: 'c1', thirdChoiceStatus: 'reviewing' },
+    ]);
+
+    // An application where committee c1 is the 1st choice (status accepted)
+    // but an unrelated 2nd choice happens to be "reviewing" must NOT match
+    // any clause — proves the fields aren't independently ORed.
+    const wouldFalselyMatchOldLogic = {
+      firstChoiceCommittee: 'c1',
+      firstChoiceStatus: 'accepted',
+      secondChoiceCommittee: 'c2',
+      secondChoiceStatus: 'reviewing',
+    };
+    const matchesAnyClause = query.$or.some((clause) => Object.entries(clause).every(
+      ([field, value]) => wouldFalselyMatchOldLogic[field] === value,
+    ));
+    expect(matchesAnyClause).toBe(false);
+  });
+
+  test('officer scope and an explicit status combine per-slot too', async () => {
+    setupFind();
+    Committee.find.mockReturnValue({
+      select: jest.fn().mockResolvedValue([
+        { id: 'committee-1', name: 'Hack', displayName: 'Hack' },
+      ]),
+    });
+    const officerUser = {
+      uuid: 'officer-uuid',
+      isAdmin: () => false,
+      isOfficer: () => true,
+      committees: ['Hack'],
+    };
+    const req = { user: officerUser, query: { status: 'reviewing' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toEqual([
+      { firstChoiceCommittee: { $in: ['committee-1'] }, firstChoiceStatus: 'reviewing' },
+      { secondChoiceCommittee: { $in: ['committee-1'] }, secondChoiceStatus: 'reviewing' },
+      { thirdChoiceCommittee: { $in: ['committee-1'] }, thirdChoiceStatus: 'reviewing' },
+    ]);
+  });
+
+  test('choiceRank restricts officer scoping to one specific slot, not any slot', async () => {
+    setupFind();
+    Committee.find.mockReturnValue({
+      select: jest.fn().mockResolvedValue([
+        { id: 'committee-1', name: 'Hack', displayName: 'Hack' },
+      ]),
+    });
+    const officerUser = {
+      uuid: 'officer-uuid',
+      isAdmin: () => false,
+      isOfficer: () => true,
+      committees: ['Hack'],
+    };
+    const req = { user: officerUser, query: { choiceRank: '2' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toEqual([
+      { secondChoiceCommittee: { $in: ['committee-1'] } },
+    ]);
+  });
+});
+
+describe('getApplicationStatusCounts', () => {
+  test('officer gets counts scoped to their own committee via aggregation', async () => {
+    Committee.find.mockReturnValue({
+      select: jest.fn().mockResolvedValue([
+        { id: '507f1f77bcf86cd799439011', name: 'Hack', displayName: 'Hack' },
+      ]),
+    });
+    InternshipApplication.aggregate.mockResolvedValue([
+      { _id: 'pending', count: 3 },
+      { _id: 'reviewing', count: 5 },
+    ]);
+    const officerUser = {
+      uuid: 'officer-uuid',
+      isAdmin: () => false,
+      isOfficer: () => true,
+      committees: ['Hack'],
+    };
+
+    const res = mockRes();
+    await getApplicationStatusCounts({ user: officerUser, query: {} }, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      counts: { pending: 3, reviewing: 5 },
+    });
+  });
+
+  test('admin must pass a committeeId, or gets a 400', async () => {
+    const res = mockRes();
+    const adminUserForCounts = { isAdmin: () => true, isOfficer: () => false };
+
+    await getApplicationStatusCounts({ user: adminUserForCounts, query: {} }, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(InternshipApplication.aggregate).not.toHaveBeenCalled();
+  });
+
+  test('returns empty counts when the officer has no committees', async () => {
+    const res = mockRes();
+    const officerWithNoCommittees = {
+      uuid: 'officer-uuid',
+      isAdmin: () => false,
+      isOfficer: () => true,
+      committees: [],
+    };
+
+    await getApplicationStatusCounts({ user: officerWithNoCommittees, query: {} }, res);
+
+    expect(res.json).toHaveBeenCalledWith({ success: true, counts: {} });
+    expect(InternshipApplication.aggregate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/committee-endpoints.test.js
+++ b/tests/committee-endpoints.test.js
@@ -313,7 +313,7 @@ describe('getAllCommitteesAdmin (applicationCount)', () => {
     expect(InternshipApplication.aggregate).toHaveBeenCalledTimes(1);
     const pipeline = InternshipApplication.aggregate.mock.calls[0][0];
     expect(pipeline[0]).toEqual({
-      $match: { deletedAt: null, submissionStatus: 'submitted' },
+      $match: { deletedAt: null, archivedAt: null, submissionStatus: 'submitted' },
     });
     // $setUnion across the three choice fields ensures one application doesn't double-count
     // a committee selected in multiple slots.


### PR DESCRIPTION
## Description
                                            
- Adds application-cycle tracking (InternshipSettings, cycleController) so admins can view the current/past cycle and advance to a new one, archiving the outgoing cycle's applications per committee.                                      - Adds committee ad/archive) as alighter-weight alternative to deactivation — clears current-cycle appl committee documentitself.
- Adds a per-status application count endpoint (GET /applications/statin dashboards canshow counts without paginating through all applications.
- Frontend: officer and admin dashboards get real cycle/status-count data, a new CommitteeForm for creating/editing committees, and matching server actions (advanceApplicationCycle, archiveCommittee, tionCycle,fetchApplicationStatusCounts, updateCommittee).

## Backend Specific
- New: controllers/cycleController.js, models/InternshipSettings.js, tests/committee-archive-cycle.test.js
- Changed: applicationController.js (status-counts endpoint, officer scoping), committeeController.js (archive endpoint), index.js (new routes), validation.js, InternshipApplication.js, seed scripts

## Test plan

- [ ] npm test in both repos
- [ ] Advance a cycle as admin, confirm outgoing applications archive correctly
- [ ] Archive a single committee, confirm its applications clear without deactivating the committee
- [ ] Officer dashboard status counts match actual application data
- [ ] Create/edit a committee via the new CommitteeForm