### PR TITLE
feat/intership cycle mgmt

### DIFF
--- a/app/api/v1/internship/controllers/applicationController.js
+++ b/app/api/v1/internship/controllers/applicationController.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const {
   InternshipApplication,
   getCurrentApplicationCycle,
@@ -108,7 +109,7 @@ async function getOfficerCommitteeIds(user) {
 // Create a new internship application
 async function createApplication(req, res) {
   try {
-    const applicationCycle = getCurrentApplicationCycle();
+    const applicationCycle = await getCurrentApplicationCycle();
 
     const existingApplication = await InternshipApplication.findOne({
       userId: req.user.uuid,
@@ -236,12 +237,21 @@ async function getAllApplications(req, res) {
       thirdChoiceCommittee,
       applicationCycle,
       userId,
+      search,
+      archived,
+      committeeId,
+      status,
+      choiceRank,
       page = 1,
       limit = 10,
     } = req.query;
 
     // Build query object with validated parameters
     const query = {};
+    // Committee-scope (officer auto-scope, or an explicit committeeId
+    // filter) and free-text search each need their own $or clause; collect
+    // them here and combine via $and so neither clobbers the other.
+    const andConditions = [];
 
     // Officer scoping logic
     const isOfficer = typeof req.user.isOfficer === 'function' && req.user.isOfficer();
@@ -249,6 +259,7 @@ async function getAllApplications(req, res) {
     const includeDrafts = isAdmin && req.query.includeDrafts === 'true';
 
     let officerCommitteeIds = null;
+    let committeeCondition = null;
 
     if (isOfficer && !isAdmin) {
       const officerCommittees = getOfficerCommittees(req.user);
@@ -260,17 +271,68 @@ async function getAllApplications(req, res) {
       // Comparing lowercased names directly against Committee.name would silently match
       // nothing, since committee names are stored in display casing (e.g. "ICPC").
       officerCommitteeIds = await getOfficerCommitteeIds(req.user);
+      committeeCondition = { $in: officerCommitteeIds };
+    } else if (committeeId && typeof committeeId === 'string') {
+      // "This application chose committee X in any of its 3 choice slots" —
+      // distinct from the strict per-slot firstChoiceCommittee/etc. filters
+      // below, which match one specific slot. Since the 3 slots can never
+      // repeat the same committee, an equality filter on all 3 at once would
+      // never match anything; this is the correct "any slot" filter.
+      committeeCondition = committeeId;
+    }
 
-      // Scope query: application must have at least one choice in officer's committees
-      query.$or = [
-        { firstChoiceCommittee: { $in: officerCommitteeIds } },
-        { secondChoiceCommittee: { $in: officerCommitteeIds } },
-        { thirdChoiceCommittee: { $in: officerCommitteeIds } },
-      ];
+    // "This application's committee-matching slot (see committeeCondition
+    // above) also has status X" — status must be paired with committee
+    // scope PER SLOT, not as an independent "any slot has status X" clause.
+    // Otherwise "committee A, status reviewing" could wrongly match an
+    // application where committee A's own slot is "accepted" but some other,
+    // unrelated slot happens to be "reviewing".
+    const hasStatusFilter = status && typeof status === 'string';
+    // choiceRank ("1"|"2"|"3") restricts matching to one specific slot
+    // instead of "any slot" — used by the officer dashboard's choice-rank
+    // filter, since an officer only cares about the single slot (if any)
+    // that's their own committee.
+    const choiceSlots = ['1', '2', '3'].includes(choiceRank)
+      ? [CHOICE_FIELDS[Number(choiceRank) - 1]]
+      : CHOICE_FIELDS;
+    const hasChoiceRankFilter = choiceSlots.length < CHOICE_FIELDS.length;
+    if (committeeCondition !== null || hasStatusFilter || hasChoiceRankFilter) {
+      andConditions.push({
+        $or: choiceSlots.map(({ committeeField, statusField }) => {
+          const clause = {};
+          if (committeeCondition !== null) clause[committeeField] = committeeCondition;
+          if (hasStatusFilter) clause[statusField] = status;
+          return clause;
+        }),
+      });
+    }
+
+    // Free-text search over applicant name/email
+    if (search && typeof search === 'string') {
+      const escapedSearch = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const searchRegex = new RegExp(escapedSearch, 'i');
+      andConditions.push({
+        $or: [
+          { firstName: searchRegex },
+          { lastName: searchRegex },
+          { email: searchRegex },
+        ],
+      });
+    }
+
+    if (andConditions.length === 1) {
+      Object.assign(query, andConditions[0]);
+    } else if (andConditions.length > 1) {
+      query.$and = andConditions;
     }
 
     // Always exclude soft-deleted records
     query.deletedAt = null;
+
+    // Archived applications (a past, closed cycle) are hidden from the
+    // default view; ?archived=true switches to the read-only past-cycles
+    // view showing only archived applications.
+    query.archivedAt = archived === true || archived === 'true' ? { $ne: null } : null;
 
     // Officers should not see drafts; admins can opt in
     if (!includeDrafts) {
@@ -340,6 +402,79 @@ async function getAllApplications(req, res) {
   }
 }
 
+// Per-status counts across ALL of a committee's current, non-archived,
+// submitted applications (not just one page) — "my status" is whichever
+// slot's committee matches, mirroring the officer dashboard's
+// enrichForCommittee logic. Powers the officer dashboard's stats pills,
+// which need true totals independent of the current page/filters.
+async function getApplicationStatusCounts(req, res) {
+  try {
+    const isOfficer = typeof req.user.isOfficer === 'function' && req.user.isOfficer();
+    const isAdmin = typeof req.user.isAdmin === 'function' && req.user.isAdmin();
+
+    let committeeIds;
+    if (isOfficer && !isAdmin) {
+      committeeIds = await getOfficerCommitteeIds(req.user);
+    } else if (isAdmin && req.query.committeeId) {
+      committeeIds = [req.query.committeeId];
+    } else {
+      return res.status(400).json({ success: false, message: 'committeeId is required for admin requests' });
+    }
+
+    if (!committeeIds.length) {
+      return res.json({ success: true, counts: {} });
+    }
+
+    const committeeObjectIds = committeeIds.map(
+      (id) => (typeof id === 'string' ? new mongoose.Types.ObjectId(id) : id),
+    );
+
+    const results = await InternshipApplication.aggregate([
+      {
+        $match: {
+          deletedAt: null,
+          archivedAt: null,
+          submissionStatus: 'submitted',
+          $or: [
+            { firstChoiceCommittee: { $in: committeeObjectIds } },
+            { secondChoiceCommittee: { $in: committeeObjectIds } },
+            { thirdChoiceCommittee: { $in: committeeObjectIds } },
+          ],
+        },
+      },
+      {
+        $addFields: {
+          myStatus: {
+            $switch: {
+              branches: [
+                { case: { $in: ['$firstChoiceCommittee', committeeObjectIds] }, then: '$firstChoiceStatus' },
+                { case: { $in: ['$secondChoiceCommittee', committeeObjectIds] }, then: '$secondChoiceStatus' },
+                { case: { $in: ['$thirdChoiceCommittee', committeeObjectIds] }, then: '$thirdChoiceStatus' },
+              ],
+              default: null,
+            },
+          },
+        },
+      },
+      { $match: { myStatus: { $ne: null } } },
+      { $group: { _id: '$myStatus', count: { $sum: 1 } } },
+    ]);
+
+    const counts = {};
+    results.forEach((row) => {
+      counts[row._id] = row.count;
+    });
+
+    return res.json({ success: true, counts });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: 'Error fetching application status counts',
+      error: error.message,
+    });
+  }
+}
+
 // Get a single internship application by ID
 async function getApplicationById(req, res) {
   try {
@@ -395,7 +530,7 @@ async function getApplicationById(req, res) {
 // Get the authenticated user's own application
 async function getOwnApplication(req, res) {
   try {
-    const applicationCycle = getCurrentApplicationCycle();
+    const applicationCycle = await getCurrentApplicationCycle();
     const application = await InternshipApplication.findOne({
       userId: req.user.uuid,
       applicationCycle,
@@ -849,6 +984,7 @@ async function submitApplication(req, res) {
 module.exports = {
   createApplication,
   getAllApplications,
+  getApplicationStatusCounts,
   getApplicationById,
   updateApplication,
   updateApplicationStatus,

--- a/app/api/v1/internship/controllers/committeeController.js
+++ b/app/api/v1/internship/controllers/committeeController.js
@@ -1,13 +1,15 @@
 const { Committee } = require('../models/Committee');
 const { InternshipApplication } = require('../models/InternshipApplication');
 const { canManageCommitteeResource } = require('../../auth/committeeScope');
+const { getCurrentCycle } = require('../models/InternshipSettings');
 const error = require('../../../../error');
 
-// Count submitted (non-deleted) applications per committee across all 3 choice slots.
-// $setUnion dedupes per application so a committee selected in multiple slots only counts once.
+// Count submitted (non-deleted, non-archived) applications per committee across all 3 choice
+// slots. $setUnion dedupes per application so a committee selected in multiple slots only
+// counts once.
 async function getApplicationCountsByCommittee() {
   const counts = await InternshipApplication.aggregate([
-    { $match: { deletedAt: null, submissionStatus: 'submitted' } },
+    { $match: { deletedAt: null, archivedAt: null, submissionStatus: 'submitted' } },
     {
       $project: {
         committees: {
@@ -33,7 +35,7 @@ async function getApplicationCountsByCommittee() {
 async function getAllCommittees(req, res, next) {
   try {
     const includeInactive = req.query.includeInactive === 'true' && req.user && req.user.isAdmin();
-    const filter = {};
+    const filter = includeInactive ? {} : { isActive: true };
 
     const committees = await Committee.find(filter).select('-__v').sort({ displayName: 1 });
 
@@ -126,6 +128,41 @@ async function deleteCommittee(req, res, next) {
   }
 }
 
+// Archives this committee's current-cycle applications. The committee
+// document itself is never modified — it persists exactly as-is; it just
+// has no current-cycle applications after this runs.
+async function archiveCommittee(req, res, next) {
+  try {
+    const committee = await Committee.findById(req.params.id);
+    if (!committee) {
+      return res.status(404).json({ error: 'Committee not found' });
+    }
+
+    const currentCycle = await getCurrentCycle();
+
+    const result = await InternshipApplication.updateMany(
+      {
+        $or: [
+          { firstChoiceCommittee: committee._id },
+          { secondChoiceCommittee: committee._id },
+          { thirdChoiceCommittee: committee._id },
+        ],
+        applicationCycle: currentCycle,
+        deletedAt: null,
+        archivedAt: null,
+      },
+      { $set: { archivedAt: new Date(), archivedBy: req.user.uuid } },
+    );
+    const archivedCount = (result && (
+      result.modifiedCount !== undefined ? result.modifiedCount : result.nModified
+    )) || 0;
+
+    return res.json({ error: null, archivedCount });
+  } catch (e) {
+    return next(e);
+  }
+}
+
 async function bulkUpdateCommitteeStatus(req, res, next) {
   try {
     const { action, committeeIds } = req.body;
@@ -179,5 +216,6 @@ module.exports = {
   updateCommitteeQuestions,
   updateCommitteeAdmin,
   deleteCommittee,
+  archiveCommittee,
   bulkUpdateCommitteeStatus,
 };

--- a/app/api/v1/internship/controllers/cycleController.js
+++ b/app/api/v1/internship/controllers/cycleController.js
@@ -1,0 +1,76 @@
+const { InternshipApplication } = require('../models/InternshipApplication');
+const {
+  computeDefaultCycleLabel,
+  getCurrentCycle,
+  setCurrentCycle,
+} = require('../models/InternshipSettings');
+const error = require('../../../../error');
+
+// Bumps a "YYYY-YYYY+1" cycle label forward by one year. Falls back to a
+// fresh calendar-based label if the current cycle isn't in that shape (e.g.
+// an admin previously set a custom label).
+function suggestNextCycle(currentCycle) {
+  const match = /^(\d{4})-(\d{4})$/.exec(currentCycle);
+  if (!match) {
+    return computeDefaultCycleLabel();
+  }
+  const startYear = Number(match[1]);
+  return `${startYear + 1}-${startYear + 2}`;
+}
+
+async function getCycleInfo(req, res, next) {
+  try {
+    const currentCycle = await getCurrentCycle();
+    const pastCycles = await InternshipApplication.distinct('applicationCycle', {
+      applicationCycle: { $ne: currentCycle },
+    });
+
+    return res.json({
+      error: null,
+      currentCycle,
+      suggestedNextCycle: suggestNextCycle(currentCycle),
+      pastCycles: pastCycles.sort(),
+    });
+  } catch (e) {
+    return next(e);
+  }
+}
+
+// Archives every committee's current-cycle applications and advances the
+// stored "current" cycle. Committee documents are never touched by this —
+// they persist unchanged; they just have no current-cycle applications
+// after this runs.
+async function advanceCycle(req, res, next) {
+  try {
+    const previousCycle = await getCurrentCycle();
+    const newCycle = (req.body && req.body.newCycle) || suggestNextCycle(previousCycle);
+
+    if (typeof newCycle !== 'string' || !newCycle.trim()) {
+      throw new error.BadRequest('newCycle must be a non-empty string.');
+    }
+    if (newCycle === previousCycle) {
+      throw new error.BadRequest('newCycle must be different from the current cycle.');
+    }
+
+    const result = await InternshipApplication.updateMany(
+      { applicationCycle: previousCycle, deletedAt: null, archivedAt: null },
+      { $set: { archivedAt: new Date(), archivedBy: req.user.uuid } },
+    );
+    const archivedCount = (result && (
+      result.modifiedCount !== undefined ? result.modifiedCount : result.nModified
+    )) || 0;
+
+    await setCurrentCycle(newCycle);
+
+    return res.json({
+      error: null, previousCycle, newCycle, archivedCount,
+    });
+  } catch (e) {
+    return next(e);
+  }
+}
+
+module.exports = {
+  getCycleInfo,
+  advanceCycle,
+};

--- a/app/api/v1/internship/index.js
+++ b/app/api/v1/internship/index.js
@@ -8,6 +8,7 @@ const adminOrOfficer = require('../auth').isOfficerOrAdmin;
 const {
   createApplication,
   getAllApplications,
+  getApplicationStatusCounts,
   getApplicationById,
   updateApplication,
   updateApplicationStatus,
@@ -24,8 +25,10 @@ const {
   updateCommitteeQuestions,
   updateCommitteeAdmin,
   deleteCommittee,
+  archiveCommittee,
   bulkUpdateCommitteeStatus,
 } = require('./controllers/committeeController');
+const { getCycleInfo, advanceCycle } = require('./controllers/cycleController');
 const {
   validateCreateApplication,
   validateUpdateApplication,
@@ -43,6 +46,9 @@ router.get('/applications', auth, adminOrOfficer, getApplicationsLimiter, valida
 
 // GET own application (authenticated non-admin user)
 router.get('/applications/me', auth, getApplicationsLimiter, getOwnApplication);
+
+// GET per-status application counts for a committee (officers and admins) - must be before /:id
+router.get('/applications/status-counts', auth, adminOrOfficer, getApplicationsLimiter, getApplicationStatusCounts);
 
 // GET a single application by ID (officers only)
 router.get('/applications/:id', auth, officer, getApplicationsLimiter, getApplicationById);
@@ -90,5 +96,14 @@ router.put('/committees/:id/questions', auth, adminOrOfficer, committeeRateLimit
 
 // DELETE committee (admin only) - soft delete by setting isActive to false
 router.delete('/committees/:id', auth, admin, deleteCommittee);
+
+// ARCHIVE a committee's current-cycle applications (admin only)
+router.post('/committees/:id/archive', auth, admin, committeeRateLimiter, archiveCommittee);
+
+// GET the current/past application cycle info (admin only)
+router.get('/cycle', auth, admin, getCycleInfo);
+
+// POST advance to a new application cycle, archiving the outgoing cycle (admin only)
+router.post('/cycle/advance', auth, admin, committeeRateLimiter, advanceCycle);
 
 module.exports = { router };

--- a/app/api/v1/internship/middleware/validation.js
+++ b/app/api/v1/internship/middleware/validation.js
@@ -334,6 +334,15 @@ const validateGetApplications = [
     .withMessage('Third choice committee must be a valid MongoDB ID'),
   query('applicationCycle').optional().trim(),
   query('userId').optional().trim(),
+  query('search').optional().trim()
+    .isLength({ max: 100 })
+    .withMessage('Search must be 100 characters or fewer'),
+  query('archived').optional().isBoolean()
+    .withMessage('archived must be a boolean')
+    .toBoolean(),
+  query('committeeId').optional().isMongoId().withMessage('committeeId must be a valid MongoDB ID'),
+  query('status').optional().isIn(STATUS_OPTIONS).withMessage('Invalid status filter'),
+  query('choiceRank').optional().isIn(['1', '2', '3']).withMessage('choiceRank must be 1, 2, or 3'),
   query('page').optional().isInt({ min: 1 }).withMessage('Page must be a positive integer'),
   query('limit')
     .optional()

--- a/app/api/v1/internship/models/Committee.js
+++ b/app/api/v1/internship/models/Committee.js
@@ -31,10 +31,6 @@ const CommitteeSchema = new Schema(
       type: String,
       required: false,
     },
-    subcommittees: {
-      type: [String],
-      default: [],
-    },
     isActive: {
       type: Boolean,
       default: true,

--- a/app/api/v1/internship/models/InternshipApplication.js
+++ b/app/api/v1/internship/models/InternshipApplication.js
@@ -1,11 +1,20 @@
 const mongoose = require('mongoose');
 const { MIN_GRADUATION_YEAR } = require('../config/constants');
+const { computeDefaultCycleLabel, getCurrentCycle } = require('./InternshipSettings');
 
 const { Schema } = mongoose;
 
-function getCurrentApplicationCycle(referenceDate = new Date()) {
-  const year = referenceDate.getFullYear();
-  return `${year}-${year + 1}`;
+// Used only as the Mongoose schema default below (a synchronous fallback for
+// direct `new InternshipApplication()` construction outside request context,
+// e.g. tests/seed scripts). Real request flows call the async
+// getCurrentApplicationCycle() below instead, which reads the admin-settable
+// stored cycle.
+function getCurrentApplicationCycleDefault(referenceDate = new Date()) {
+  return computeDefaultCycleLabel(referenceDate);
+}
+
+async function getCurrentApplicationCycle() {
+  return getCurrentCycle();
 }
 
 const InternshipApplicationSchema = new Schema(
@@ -199,7 +208,7 @@ const InternshipApplicationSchema = new Schema(
       type: String,
       required: true,
       index: true,
-      default: getCurrentApplicationCycle,
+      default: getCurrentApplicationCycleDefault,
     },
     // Tracks member submission, not officer review
     submissionStatus: {
@@ -214,6 +223,19 @@ const InternshipApplicationSchema = new Schema(
       index: true,
     },
     deletedBy: {
+      type: String,
+      default: null,
+    },
+    // Set when an admin archives this application's cycle (either via a
+    // per-committee archive or a global "start new cycle" action). Distinct
+    // from deletedAt/deletedBy: archived applications persist and remain
+    // visible in past-cycle views, they're just excluded from current views.
+    archivedAt: {
+      type: Date,
+      default: null,
+      index: true,
+    },
+    archivedBy: {
       type: String,
       default: null,
     },

--- a/app/api/v1/internship/models/InternshipSettings.js
+++ b/app/api/v1/internship/models/InternshipSettings.js
@@ -1,0 +1,51 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+function computeDefaultCycleLabel(referenceDate = new Date()) {
+  const year = referenceDate.getFullYear();
+  return `${year}-${year + 1}`;
+}
+
+// Singleton collection: exactly one document tracks the admin-controlled
+// "current" application cycle. Applications stamp this value at creation
+// time so archiving/advancing the cycle can bulk-select "everything in the
+// outgoing cycle" without depending on wall-clock date math.
+const InternshipSettingsSchema = new Schema(
+  {
+    currentApplicationCycle: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+const InternshipSettings = mongoose.model('InternshipSettings', InternshipSettingsSchema);
+
+async function getCurrentCycle() {
+  const settings = await InternshipSettings.findOneAndUpdate(
+    {},
+    { $setOnInsert: { currentApplicationCycle: computeDefaultCycleLabel() } },
+    { new: true, upsert: true },
+  );
+  return settings.currentApplicationCycle;
+}
+
+async function setCurrentCycle(newCycle) {
+  const settings = await InternshipSettings.findOneAndUpdate(
+    {},
+    { $set: { currentApplicationCycle: newCycle } },
+    { new: true, upsert: true },
+  );
+  return settings.currentApplicationCycle;
+}
+
+module.exports = {
+  InternshipSettings,
+  computeDefaultCycleLabel,
+  getCurrentCycle,
+  setCurrentCycle,
+};

--- a/scripts/seed-internship-test-data.js
+++ b/scripts/seed-internship-test-data.js
@@ -18,7 +18,6 @@ const mongoUri = process.env.MONGODB_URI
   || `mongodb://${mongoUser}:${mongoPassword}@${mongoHost}:${mongoPort}/${mongoDatabase}?authSource=admin`;
 const seedEmail = process.env.SEED_EMAIL || process.env.SEED_USER_EMAIL || '';
 const seedUuid = process.env.SEED_USER_UUID || '';
-const applicationCycle = process.env.SEED_APPLICATION_CYCLE || getCurrentApplicationCycle();
 const applicationStatus = (process.env.SEED_STATUS || 'draft').toLowerCase();
 const defaultCommitteeNames = 'Hack,AI,Design,Cyber,ICPC,Studio,TeachLA,W,Cloud';
 const committeeNames = (process.env.SEED_COMMITTEES || defaultCommitteeNames)
@@ -323,7 +322,6 @@ function getCommitteeSeed(name, index) {
     update: {
       name: displayName,
       displayName,
-      subcommittees: [],
       isActive: shouldCommitteeBeActive(index),
       internLimit: Number(process.env.SEED_INTERN_LIMIT || 10),
       applicationDeadline: new Date(process.env.SEED_APPLICATION_DEADLINE || '2030-10-15T23:59:59.000Z'),
@@ -393,6 +391,9 @@ async function main() {
 
     await db.authenticate();
     await mongoose.connect(mongoUri);
+
+    const applicationCycle = process.env.SEED_APPLICATION_CYCLE
+      || await getCurrentApplicationCycle();
 
     const user = await resolveSeedUser();
 

--- a/scripts/seed-officer-test-applications.js
+++ b/scripts/seed-officer-test-applications.js
@@ -17,7 +17,7 @@ const mongoUri = process.env.MONGODB_URI
   || `mongodb://${mongoUser}:${mongoPassword}@${mongoHost}:${mongoPort}/${mongoDatabase}?authSource=admin`;
 
 const targetCommitteeName = process.argv[2] || process.env.SEED_OFFICER_COMMITTEE || 'ICPC';
-const applicationCycle = process.env.SEED_APPLICATION_CYCLE || getCurrentApplicationCycle();
+let applicationCycle;
 
 const STATUS_OPTIONS = ['pending', 'reviewing', 'interview_scheduled', 'accepted', 'rejected'];
 const MAJORS = ['Computer Science', 'Computer Science and Engineering', 'Electrical Engineering', 'Statistics and Data Science', 'Mathematics', 'Cognitive Science'];
@@ -135,6 +135,8 @@ function buildApplicant(index, targetCommittee, otherCommittees) {
 
 async function main() {
   await mongoose.connect(mongoUri);
+
+  applicationCycle = process.env.SEED_APPLICATION_CYCLE || await getCurrentApplicationCycle();
 
   const targetCommittee = await Committee.findOne({
     $or: [{ name: targetCommitteeName }, { displayName: targetCommitteeName }],

--- a/tests/committee-archive-cycle.test.js
+++ b/tests/committee-archive-cycle.test.js
@@ -1,0 +1,447 @@
+jest.mock('google-auth-library', () => ({
+  OAuth2Client: jest.fn().mockImplementation(() => ({
+    verifyIdToken: jest.fn(),
+  })),
+}), { virtual: true });
+
+jest.mock('../app/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  log: jest.fn(),
+}));
+
+jest.mock('../app/api/v1/internship/models/Committee', () => ({
+  Committee: {
+    findById: jest.fn(),
+    find: jest.fn(),
+  },
+}));
+
+jest.mock('../app/api/v1/internship/models/InternshipApplication', () => ({
+  InternshipApplication: {
+    updateMany: jest.fn(),
+    distinct: jest.fn(),
+    find: jest.fn(),
+    countDocuments: jest.fn(),
+    aggregate: jest.fn(),
+  },
+  getCurrentApplicationCycle: jest.fn(),
+}));
+
+jest.mock('../app/api/v1/internship/models/InternshipSettings', () => ({
+  computeDefaultCycleLabel: jest.fn(() => '2099-2100'),
+  getCurrentCycle: jest.fn(),
+  setCurrentCycle: jest.fn(),
+}));
+
+const { Committee } = require('../app/api/v1/internship/models/Committee');
+const { InternshipApplication } = require('../app/api/v1/internship/models/InternshipApplication');
+const { getCurrentCycle, setCurrentCycle } = require('../app/api/v1/internship/models/InternshipSettings');
+const { archiveCommittee } = require('../app/api/v1/internship/controllers/committeeController');
+const { getCycleInfo, advanceCycle } = require('../app/api/v1/internship/controllers/cycleController');
+const { getAllApplications, getApplicationStatusCounts } = require('../app/api/v1/internship/controllers/applicationController');
+const error = require('../app/error');
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const adminUser = {
+  uuid: 'admin-uuid',
+  isAdmin: () => true,
+  isOfficer: () => false,
+  hasCommittee: () => false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('archiveCommittee', () => {
+  test('returns 404 when the committee does not exist', async () => {
+    Committee.findById.mockResolvedValue(null);
+
+    const req = { params: { id: 'missing' }, user: adminUser };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await archiveCommittee(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Committee not found' });
+    expect(InternshipApplication.updateMany).not.toHaveBeenCalled();
+  });
+
+  test('archives only the current cycle\'s applications for this committee, leaving the committee doc untouched', async () => {
+    const committeeDoc = { _id: 'c1' };
+    Committee.findById.mockResolvedValue(committeeDoc);
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    InternshipApplication.updateMany.mockResolvedValue({ modifiedCount: 7 });
+
+    const req = { params: { id: 'c1' }, user: adminUser };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await archiveCommittee(req, res, next);
+
+    expect(InternshipApplication.updateMany).toHaveBeenCalledWith(
+      {
+        $or: [
+          { firstChoiceCommittee: 'c1' },
+          { secondChoiceCommittee: 'c1' },
+          { thirdChoiceCommittee: 'c1' },
+        ],
+        applicationCycle: '2026-2027',
+        deletedAt: null,
+        archivedAt: null,
+      },
+      { $set: { archivedAt: expect.any(Date), archivedBy: 'admin-uuid' } },
+    );
+    expect(res.json).toHaveBeenCalledWith({ error: null, archivedCount: 7 });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('forwards errors to next()', async () => {
+    Committee.findById.mockRejectedValue(new Error('mongo down'));
+    const next = jest.fn();
+
+    await archiveCommittee({ params: { id: 'c1' }, user: adminUser }, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+
+describe('getCycleInfo', () => {
+  test('returns current cycle, past cycles (excluding current), and a suggested next cycle', async () => {
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    InternshipApplication.distinct.mockResolvedValue(['2024-2025', '2025-2026']);
+
+    const res = mockRes();
+    await getCycleInfo({ user: adminUser }, res, jest.fn());
+
+    expect(InternshipApplication.distinct).toHaveBeenCalledWith('applicationCycle', {
+      applicationCycle: { $ne: '2026-2027' },
+    });
+    expect(res.json).toHaveBeenCalledWith({
+      error: null,
+      currentCycle: '2026-2027',
+      suggestedNextCycle: '2027-2028',
+      pastCycles: ['2024-2025', '2025-2026'],
+    });
+  });
+
+  test('falls back to computeDefaultCycleLabel when the current cycle is a non-standard custom label', async () => {
+    getCurrentCycle.mockResolvedValue('Custom Cycle Label');
+    InternshipApplication.distinct.mockResolvedValue([]);
+
+    const res = mockRes();
+    await getCycleInfo({ user: adminUser }, res, jest.fn());
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.suggestedNextCycle).toBe('2099-2100');
+  });
+});
+
+describe('advanceCycle', () => {
+  test('archives the outgoing cycle\'s applications and stores the new current cycle', async () => {
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    InternshipApplication.updateMany.mockResolvedValue({ modifiedCount: 42 });
+
+    const req = { user: adminUser, body: { newCycle: '2027-2028' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await advanceCycle(req, res, next);
+
+    expect(InternshipApplication.updateMany).toHaveBeenCalledWith(
+      { applicationCycle: '2026-2027', deletedAt: null, archivedAt: null },
+      { $set: { archivedAt: expect.any(Date), archivedBy: 'admin-uuid' } },
+    );
+    expect(setCurrentCycle).toHaveBeenCalledWith('2027-2028');
+    expect(res.json).toHaveBeenCalledWith({
+      error: null,
+      previousCycle: '2026-2027',
+      newCycle: '2027-2028',
+      archivedCount: 42,
+    });
+  });
+
+  test('defaults to the suggested next cycle when newCycle is omitted from the body', async () => {
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    InternshipApplication.updateMany.mockResolvedValue({ modifiedCount: 0 });
+
+    const req = { user: adminUser, body: {} };
+    const res = mockRes();
+
+    await advanceCycle(req, res, jest.fn());
+
+    expect(setCurrentCycle).toHaveBeenCalledWith('2027-2028');
+  });
+
+  test('rejects when newCycle equals the current cycle', async () => {
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    const next = jest.fn();
+
+    await advanceCycle({ user: adminUser, body: { newCycle: '2026-2027' } }, mockRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const passed = next.mock.calls[0][0];
+    expect(passed).toBeInstanceOf(error.BadRequest);
+    expect(InternshipApplication.updateMany).not.toHaveBeenCalled();
+    expect(setCurrentCycle).not.toHaveBeenCalled();
+  });
+
+  test('rejects a blank newCycle', async () => {
+    getCurrentCycle.mockResolvedValue('2026-2027');
+    const next = jest.fn();
+
+    await advanceCycle({ user: adminUser, body: { newCycle: '   ' } }, mockRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(error.BadRequest);
+  });
+});
+
+describe('getAllApplications — search and archived query params', () => {
+  const setupFind = () => {
+    InternshipApplication.find.mockReturnValue({
+      sort: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([]),
+    });
+    InternshipApplication.countDocuments.mockResolvedValue(0);
+  };
+
+  test('defaults to excluding archived applications (archivedAt: null)', async () => {
+    setupFind();
+    const req = { user: adminUser, query: {} };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.archivedAt).toBeNull();
+  });
+
+  test('archived=true returns only archived applications', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { archived: true } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.archivedAt).toEqual({ $ne: null });
+  });
+
+  test('search builds a case-insensitive $or across firstName/lastName/email', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { search: 'ada' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toHaveLength(3);
+    expect(query.$or[0].firstName).toBeInstanceOf(RegExp);
+    expect(query.$or[0].firstName.flags).toContain('i');
+    expect(query.$or[0].firstName.test('Ada Lovelace')).toBe(true);
+  });
+
+  test('search input is regex-escaped so special characters cannot break the query', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { search: 'a.b+c' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    const emailRegex = query.$or[2].email;
+    expect(emailRegex.test('a.b+c@example.com')).toBe(true);
+    expect(emailRegex.test('axbxc@example.com')).toBe(false);
+  });
+
+  test('officer committee-scope and search combine via $and instead of clobbering each other', async () => {
+    setupFind();
+    Committee.find.mockReturnValue({
+      select: jest.fn().mockResolvedValue([
+        { id: 'committee-1', name: 'Hack', displayName: 'Hack' },
+      ]),
+    });
+    const officerUser = {
+      uuid: 'officer-uuid',
+      isAdmin: () => false,
+      isOfficer: () => true,
+      committees: ['Hack'],
+    };
+    const req = { user: officerUser, query: { search: 'ada' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toBeUndefined();
+    expect(query.$and).toHaveLength(2);
+    expect(query.$and[0].$or[0]).toHaveProperty('firstChoiceCommittee');
+    expect(query.$and[1].$or[0]).toHaveProperty('firstName');
+  });
+
+  test('committeeId matches any of the 3 choice slots, not just the first', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { committeeId: 'c1' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toEqual([
+      { firstChoiceCommittee: 'c1' },
+      { secondChoiceCommittee: 'c1' },
+      { thirdChoiceCommittee: 'c1' },
+    ]);
+  });
+
+  test('status matches any of the 3 choice slots, not just the first', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { status: 'reviewing' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toEqual([
+      { firstChoiceStatus: 'reviewing' },
+      { secondChoiceStatus: 'reviewing' },
+      { thirdChoiceStatus: 'reviewing' },
+    ]);
+  });
+
+  test('committeeId and status are paired per-slot, not independently — a different slot with the same status must not match', async () => {
+    setupFind();
+    const req = { user: adminUser, query: { committeeId: 'c1', status: 'reviewing' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    // Combined into one $or (not two separate $and members), so each clause
+    // requires committee AND status on the SAME slot.
+    expect(query.$or).toEqual([
+      { firstChoiceCommittee: 'c1', firstChoiceStatus: 'reviewing' },
+      { secondChoiceCommittee: 'c1', secondChoiceStatus: 'reviewing' },
+      { thirdChoiceCommittee: 'c1', thirdChoiceStatus: 'reviewing' },
+    ]);
+
+    // An application where committee c1 is the 1st choice (status accepted)
+    // but an unrelated 2nd choice happens to be "reviewing" must NOT match
+    // any clause — proves the fields aren't independently ORed.
+    const wouldFalselyMatchOldLogic = {
+      firstChoiceCommittee: 'c1',
+      firstChoiceStatus: 'accepted',
+      secondChoiceCommittee: 'c2',
+      secondChoiceStatus: 'reviewing',
+    };
+    const matchesAnyClause = query.$or.some((clause) => Object.entries(clause).every(
+      ([field, value]) => wouldFalselyMatchOldLogic[field] === value,
+    ));
+    expect(matchesAnyClause).toBe(false);
+  });
+
+  test('officer scope and an explicit status combine per-slot too', async () => {
+    setupFind();
+    Committee.find.mockReturnValue({
+      select: jest.fn().mockResolvedValue([
+        { id: 'committee-1', name: 'Hack', displayName: 'Hack' },
+      ]),
+    });
+    const officerUser = {
+      uuid: 'officer-uuid',
+      isAdmin: () => false,
+      isOfficer: () => true,
+      committees: ['Hack'],
+    };
+    const req = { user: officerUser, query: { status: 'reviewing' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toEqual([
+      { firstChoiceCommittee: { $in: ['committee-1'] }, firstChoiceStatus: 'reviewing' },
+      { secondChoiceCommittee: { $in: ['committee-1'] }, secondChoiceStatus: 'reviewing' },
+      { thirdChoiceCommittee: { $in: ['committee-1'] }, thirdChoiceStatus: 'reviewing' },
+    ]);
+  });
+
+  test('choiceRank restricts officer scoping to one specific slot, not any slot', async () => {
+    setupFind();
+    Committee.find.mockReturnValue({
+      select: jest.fn().mockResolvedValue([
+        { id: 'committee-1', name: 'Hack', displayName: 'Hack' },
+      ]),
+    });
+    const officerUser = {
+      uuid: 'officer-uuid',
+      isAdmin: () => false,
+      isOfficer: () => true,
+      committees: ['Hack'],
+    };
+    const req = { user: officerUser, query: { choiceRank: '2' } };
+
+    await getAllApplications(req, mockRes());
+
+    const query = InternshipApplication.find.mock.calls[0][0];
+    expect(query.$or).toEqual([
+      { secondChoiceCommittee: { $in: ['committee-1'] } },
+    ]);
+  });
+});
+
+describe('getApplicationStatusCounts', () => {
+  test('officer gets counts scoped to their own committee via aggregation', async () => {
+    Committee.find.mockReturnValue({
+      select: jest.fn().mockResolvedValue([
+        { id: '507f1f77bcf86cd799439011', name: 'Hack', displayName: 'Hack' },
+      ]),
+    });
+    InternshipApplication.aggregate.mockResolvedValue([
+      { _id: 'pending', count: 3 },
+      { _id: 'reviewing', count: 5 },
+    ]);
+    const officerUser = {
+      uuid: 'officer-uuid',
+      isAdmin: () => false,
+      isOfficer: () => true,
+      committees: ['Hack'],
+    };
+
+    const res = mockRes();
+    await getApplicationStatusCounts({ user: officerUser, query: {} }, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      counts: { pending: 3, reviewing: 5 },
+    });
+  });
+
+  test('admin must pass a committeeId, or gets a 400', async () => {
+    const res = mockRes();
+    const adminUserForCounts = { isAdmin: () => true, isOfficer: () => false };
+
+    await getApplicationStatusCounts({ user: adminUserForCounts, query: {} }, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(InternshipApplication.aggregate).not.toHaveBeenCalled();
+  });
+
+  test('returns empty counts when the officer has no committees', async () => {
+    const res = mockRes();
+    const officerWithNoCommittees = {
+      uuid: 'officer-uuid',
+      isAdmin: () => false,
+      isOfficer: () => true,
+      committees: [],
+    };
+
+    await getApplicationStatusCounts({ user: officerWithNoCommittees, query: {} }, res);
+
+    expect(res.json).toHaveBeenCalledWith({ success: true, counts: {} });
+    expect(InternshipApplication.aggregate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/committee-endpoints.test.js
+++ b/tests/committee-endpoints.test.js
@@ -313,7 +313,7 @@ describe('getAllCommitteesAdmin (applicationCount)', () => {
     expect(InternshipApplication.aggregate).toHaveBeenCalledTimes(1);
     const pipeline = InternshipApplication.aggregate.mock.calls[0][0];
     expect(pipeline[0]).toEqual({
-      $match: { deletedAt: null, submissionStatus: 'submitted' },
+      $match: { deletedAt: null, archivedAt: null, submissionStatus: 'submitted' },
     });
     // $setUnion across the three choice fields ensures one application doesn't double-count
     // a committee selected in multiple slots.


### PR DESCRIPTION
## Description
                                            
- Adds application-cycle tracking (InternshipSettings, cycleController) so admins can view the current/past cycle and advance to a new one, archiving the outgoing cycle's applications per committee.                                      - Adds committee ad/archive) as alighter-weight alternative to deactivation — clears current-cycle appl committee documentitself.
- Adds a per-status application count endpoint (GET /applications/statin dashboards canshow counts without paginating through all applications.
- Frontend: officer and admin dashboards get real cycle/status-count data, a new CommitteeForm for creating/editing committees, and matching server actions (advanceApplicationCycle, archiveCommittee, tionCycle,fetchApplicationStatusCounts, updateCommittee).

## Backend Specific
- New: controllers/cycleController.js, models/InternshipSettings.js, tests/committee-archive-cycle.test.js
- Changed: applicationController.js (status-counts endpoint, officer scoping), committeeController.js (archive endpoint), index.js (new routes), validation.js, InternshipApplication.js, seed scripts

## Test plan

- [ ] npm test in both repos
- [ ] Advance a cycle as admin, confirm outgoing applications archive correctly
- [ ] Archive a single committee, confirm its applications clear without deactivating the committee
- [ ] Officer dashboard status counts match actual application data
- [ ] Create/edit a committee via the new CommitteeForm